### PR TITLE
Customize local registries in CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -8,6 +8,12 @@ on:
         default: "1"
         required: false
         type: string
+      localregistries:
+        description: 'Registries besides General to use. Specified by providing the url (https/ssh) to the Github
+                      repositories as a newline (\n) seperated list.'
+        default: ""
+        required: false
+        type: string
 
 jobs:
   CompatHelper:
@@ -42,18 +48,16 @@ jobs:
           import CompatHelper
           import Pkg
           registries = [
-              Pkg.RegistrySpec(
-                  name = "General",
-                  uuid = "23338594-aafe-5451-b93e-139f81909106",
-                  url = "https://github.com/JuliaRegistries/General.git",
-              ),
-              Pkg.RegistrySpec(
-                  name = "ITensorRegistry",
-                  uuid = "c4d53e37-7e0e-4be9-ba6f-c27e01f48020",
-                  url = "https://github.com/ITensor/ITensorRegistry.git",
-              ),
+              Pkg.RegistrySpec(; url = "https://github.com/JuliaRegistries/General.git")
           ]
-          CompatHelper.main(; registries)
+          if !isempty("${{ inputs.localregistries }}")
+            local_repos = split("${{ inputs.localregistries }}", "\n") .|> string
+            for repo_url in local_repos
+              isempty(repo_url) && continue
+              pus!(registries, Pkg.RegistrySpec(; url = repo_url))
+            end
+          end
+          CompatHelper.main(; registries, bump_version=true)
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -178,10 +178,12 @@ jobs:
 ## CompatHelper
 
 The CompatHelper workflow is designed to periodically check dependencies for breaking
-releases, and if so make PRs to bump the compat versions. The workflow would look like:
-Note this workflow checks both the Julia [General registry](https://github.com/JuliaRegistries/General)
-and the [ITensorRegistry](https://github.com/ITensor/ITensorRegistry) for breaking releases
-of dependencies.
+releases, and if so make PRs to bump the compat versions. By default this workflow
+checks the Julia [General registry](https://github.com/JuliaRegistries/General)
+for breaking releases of dependencies, but you can add other registries
+by specifying the registry repository URLs in the `localregistries` option, which should
+be a string with URLs of repositories seperated by a newline character (`\n`).
+Here is an example workflow:
 
 ```yaml
 name: "CompatHelper"
@@ -198,4 +200,6 @@ jobs:
   CompatHelper:
     name: "CompatHelper"
     uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@main"
+    with:
+      localregistries: "https://github.com/ITensor/ITensorRegistry.git"
 ```


### PR DESCRIPTION
This updates #4 to allow customizing the local registries to look in, while before it was hardcoded to look in the ITensorRegistry (now you would need to explicitly specify the ITensorRegistry, but can also search multiple local registries). I'll merge so I can test it out from another repository.