### PR TITLE
Set up CompatHelper to check test and docs

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -75,7 +75,8 @@ jobs:
               push!(registries, Pkg.RegistrySpec(; url=registry_url, name=registry_name))
             end
           end
-          CompatHelper.main(; registries, bump_version=true)
+          subdirs = ["", "test", "docs"]
+          CompatHelper.main(; registries, subdirs, bump_version=true)
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@lkdvos this sets up CompatHelper to check the test and docs `Project.toml`s.

I noticed that we don't generally have compat entries for test and docs dependencies, which causes trouble if test or docs dependencies make breaking releases, for example in https://github.com/ITensor/BlockSparseArrays.jl/pull/68. This should make it easier to add compat entries and make sure they stay updated.

I'll merge so I can start testing it out in some other packages.