### PR TITLE
Add format PR workflow

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -27,7 +27,7 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: "${{ inputs.julia-version }}"
-          arch: ${{ runner.arch }}
+          arch: "${{ runner.arch }}"
         if: steps.julia_in_path.outcome != 'success'
       - name: "Add the General registry via Git"
         run: |

--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -1,0 +1,61 @@
+name: "Reusable Format Pull Request Workflow"
+
+on:
+  workflow_call:
+    inputs:
+      directory:
+        description: "The directory on which JuliaFormatter needs to be run"
+        default: "."
+        required: false
+        type: string
+      julia-version:
+        description: "Julia version"
+        default: "1"
+        required: false
+        type: string
+      juliaformatter-version:
+        description: "Version of JuliaFormatter to use"
+        default: "1"
+        required: false
+        type: string
+
+jobs:
+  format-pull-request:
+    name: "Format Pull Request"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Setup Julia ${{ inputs.julia-version }}"
+        uses: julia-actions/setup-julia@v2
+        with: 
+          version: "${{ inputs.julia-version }}"
+          arch: "${{ runner.arch }}"
+
+      - uses: julia-actions/cache@v2
+
+      - name: Install JuliaFormatter and format
+        shell: julia --color=yes {0}
+        run: |
+          import Pkg
+          Pkg.add(PackageSpec(name="JuliaFormatter", version="${{ inputs.juliaformatter-version }}"))
+          using JuliaFormatter
+          format("./${{ inputs.directory }}", verbose=true)
+
+      # https://github.com/marketplace/actions/create-pull-request
+      # https://github.com/peter-evans/create-pull-request#reference-example
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Format .jl files
+          title: 'Automatic JuliaFormatter.jl run'
+          branch: auto-juliaformatter-pr
+          delete-branch: true
+          labels: formatting, automated pr, no changelog
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ jobs:
 ## Formatting
 
 The formatting workflow is designed to run the `JuliaFormatter` on Julia packages.
-There are two workflows available, one for simply verifying the formatting and one for additionally applying suggested changes.
+There are three workflows available: one for simply verifying the formatting, one for additionally applying suggested changes, and one that makes a PR to the repository formatting the code in the repository.
 
 ```yaml
 name: "Format Check"
@@ -152,6 +152,19 @@ jobs:
   format-suggestions:
     name: "Format Suggestions"
     uses: "ITensor/ITensorActions/workflows/FormatSuggest.yml@main"
+```
+
+```yaml
+name: "Format Pull Request"
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  format-pull-request:
+    name: "Format Pull Request"
+    uses: "ITensor/ITensorActions/workflows/FormatPullRequest.yml@main"
 ```
 
 ## LiterateCheck


### PR DESCRIPTION
This adds a workflow for making a PR to format a package, as opposed to the existing `FormatCheck.yml` that checks the formatting of a PR.

I still have to check that it works, and additionally once I confirm this version works a followup goal I have is to also have the workflow bump the patch version of the package as part of the PR. Finally, once all of it is set up and the workflow is added to our packages, I plan to change the default version of JuliaFormatter to v2 so all of the packages get updated to that version (which changes some formatting from JuliaFormatter v1).