### PR TITLE
Don't fail docs build on Codecov upload failure

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -57,7 +57,7 @@ on:
         type: boolean
     secrets:
       CODECOV_TOKEN:
-        required: true
+        required: false
 
 jobs:
   tests:
@@ -112,4 +112,4 @@ jobs:
           files: lcov.info
           flags: "docs"
           token: "${{ secrets.CODECOV_TOKEN }}"
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary

- Set `fail_ci_if_error: false` on the Codecov step in Documentation.yml
- Set `CODECOV_TOKEN` secret to `required: false`
- Fork PRs don't have the Codecov token, so the upload fails — this shouldn't block the docs build

Fixes the docs build failure on https://github.com/ITensor/NamedGraphs.jl/pull/147

🤖 Generated with [Claude Code](https://claude.com/claude-code)