### PR TITLE
Remove phantom DOCUMENTER_KEY, use COMPATHELPER_PAT

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -80,10 +80,6 @@ jobs:
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # This repo uses Documenter, so we can reuse our [Documenter SSH key](https://documenter.juliadocs.org/stable/man/hosting/walkthrough/).
-          # If we didn't have one of those setup, we could configure a dedicated ssh deploy key `COMPATHELPER_PRIV` following https://juliaregistries.github.io/CompatHelper.jl/dev/#Creating-SSH-Key.
-          # Either way, we need an SSH key if we want the PRs that CompatHelper creates to be able to trigger CI workflows themselves.
-          # That is because GITHUB_TOKEN's can't trigger other workflows (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
-          # Check if you have a deploy key setup using these docs: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/reviewing-your-deploy-keys.
-          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-          # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+          # A PAT is needed so that PRs created by CompatHelper can trigger CI workflows.
+          # GITHUB_TOKEN can't trigger other workflows (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PAT }}

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -3,10 +3,6 @@ name: "Reusable Documentation Build and Deploy Workflow"
 on:
   workflow_call:
     inputs:
-      documenter-key:
-        description: "The `DOCUMENTER_KEY` secret required for deploying the documentation built for authentication with the ssh deploy key"
-        required: false
-        type: string
       debug-documenter:
         description: "Run julia with JULIA_DEBUG set to 'Documenter'"
         default: false
@@ -97,7 +93,6 @@ jobs:
       - name: "Build and Deploy Documentation"
         env:
           GITHUB_TOKEN: ${{ inputs.github-token || secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ inputs.documenter-key || secrets.DOCUMENTER_KEY }}
         run: ${{ inputs.debug-documenter && 'JULIA_DEBUG="Documenter"' || '' }} julia --project=docs/ ${{ inputs.coverage && '--code-coverage=user' }} docs/make.jl
 
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -5,8 +5,6 @@ on:
     secrets:
       TAGBOT_PAT:
         required: false
-      DOCUMENTER_KEY:
-        required: false
 
 jobs:
   TagBotITensorRegistry:
@@ -16,11 +14,9 @@ jobs:
         with:
           token: "${{ secrets.TAGBOT_PAT || github.token }}"
           registry: "ITensor/ITensorRegistry"
-          ssh: "${{ secrets.DOCUMENTER_KEY }}"
   TagBotGeneral:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "JuliaRegistries/TagBot@v1"
         with:
           token: "${{ secrets.TAGBOT_PAT || github.token }}"
-          ssh: "${{ secrets.DOCUMENTER_KEY }}"

--- a/README.md
+++ b/README.md
@@ -251,7 +251,14 @@ jobs:
     uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@main"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
+    secrets: inherit
 ```
+
+### Secrets
+
+| Secret | Required | Description |
+|---|---|---|
+| `COMPATHELPER_PAT` | No | A fine-grained PAT with `contents: write` and `pull-requests: write` scoped to the target repos. When provided, PRs created by CompatHelper will trigger CI workflows. Without it, CompatHelper falls back to `GITHUB_TOKEN` and PRs will not trigger CI. |
 
 ## IntegrationTest
 
@@ -492,4 +499,3 @@ jobs:
 | Secret | Required | Description |
 |---|---|---|
 | `TAGBOT_PAT` | No | Personal access token used to authenticate with GitHub. Falls back to the built-in `GITHUB_TOKEN` if not provided. |
-| `DOCUMENTER_KEY` | No | SSH deploy key used to trigger documentation workflows after a release is created. |


### PR DESCRIPTION
## Summary

- Remove all `DOCUMENTER_KEY` references from CompatHelper, Documentation, and TagBot workflows. The secret was never set anywhere.
- CompatHelper now reads `COMPATHELPER_PAT` org secret so PRs trigger CI.
- Documentation workflow relies on `GITHUB_TOKEN` (Documenter.jl v1+ handles this automatically).
- TagBot drops the `ssh` parameter and continues using `TAGBOT_PAT` with `github.token` fallback.
- README updated: removed `DOCUMENTER_KEY` from TagBot secrets table, added `COMPATHELPER_PAT` docs to CompatHelper section.

## Prerequisites

Create a `COMPATHELPER_PAT` fine-grained PAT and add it as an org secret before merging. Without it, CompatHelper behavior is unchanged from today (falls back to `GITHUB_TOKEN`, PRs don't trigger CI).

## Test plan

- [ ] Verify no downstream repos pass `DOCUMENTER_KEY` explicitly (confirmed — all use `secrets: inherit`)
- [ ] After merging, trigger a CompatHelper run on any repo and confirm the resulting PR triggers CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
