### PR TITLE
Fix CompatHelper: use PAT as GITHUB_TOKEN, not COMPATHELPER_PRIV

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -79,7 +79,7 @@ jobs:
           CompatHelper.main(; registries, subdirs, bump_version=true)
         shell: julia --color=yes {0}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # A PAT is needed so that PRs created by CompatHelper can trigger CI workflows.
-          # GITHUB_TOKEN can't trigger other workflows (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
-          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PAT }}
+          # Use COMPATHELPER_PAT if available so that pushes trigger CI workflows.
+          # The built-in GITHUB_TOKEN can't trigger other workflows
+          # (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
+          GITHUB_TOKEN: ${{ secrets.COMPATHELPER_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix CompatHelper PAT usage: `COMPATHELPER_PRIV` expects an SSH key, not a PAT.
- Instead, override `GITHUB_TOKEN` with the PAT so CompatHelper's normal HTTPS push triggers CI without needing the SSH key mechanism.
- Falls back to built-in `GITHUB_TOKEN` if the PAT is not set.

## Context

Follow-up to #57. The previous approach passed the PAT as `COMPATHELPER_PRIV`, but CompatHelper.jl parses that as a PEM SSH key and errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
