### PR TITLE
Classify PRs; skip VersionCheck on non-substantive PRs

### DIFF
--- a/.github/actions/classify-pr/action.yml
+++ b/.github/actions/classify-pr/action.yml
@@ -1,0 +1,39 @@
+name: "Classify PR substance"
+description: "Determines whether a PR touches substantive files or only CI/config (workflow-only) files. Outputs substantive=true|false."
+outputs:
+  substantive:
+    description: "true if the PR touches substantive files; false if all changes are confined to .github/**, .pre-commit-config.yaml, .gitignore, or LICENSE."
+    value: ${{ steps.classify.outputs.substantive }}
+runs:
+  using: "composite"
+  steps:
+    - id: classify
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+        if [ -z "${PR_NUMBER:-}" ]; then
+          echo "Not a pull_request event; defaulting to substantive=true."
+          echo "substantive=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        files=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
+        if [ -z "$files" ]; then
+          echo "No files reported for PR #${PR_NUMBER}; defaulting to substantive=true."
+          echo "substantive=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "Changed files:"
+        printf '  %s\n' $files
+        substantive=false
+        while IFS= read -r file; do
+          case "$file" in
+            .github/*|.pre-commit-config.yaml|.gitignore|LICENSE) ;;
+            *) substantive=true; break ;;
+          esac
+        done <<< "$files"
+        echo "substantive=${substantive}"
+        echo "substantive=${substantive}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -18,19 +18,31 @@ jobs:
   version-check:
     name: "Check Versions"
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/classify-pr
+        id: classify
+
+      - name: "Skip version check on non-substantive PR"
+        if: steps.classify.outputs.substantive != 'true'
+        run: |
+          echo "PR classified as non-substantive (only .github/**, .pre-commit-config.yaml, .gitignore, LICENSE)."
+          echo "No version bump is required. Reporting success without running the real check."
+
       - uses: julia-actions/setup-julia@v2
+        if: steps.classify.outputs.substantive == 'true'
         with:
           version: ${{ inputs.julia-version }}
-      
+
       - uses: julia-actions/julia-buildpkg@latest
+        if: steps.classify.outputs.substantive == 'true'
         with:
           localregistry: "${{ inputs.localregistry }}"
-      
+
       - name: Check the Project version
+        if: steps.classify.outputs.substantive == 'true'
         shell: julia --color=yes {0}
         run: |
           using Pkg
@@ -47,8 +59,8 @@ jobs:
 
           uuid = Pkg.project().uuid
           pkg_info = find_pkg_info(uuid)
-          
+
           registered_version = maximum(keys(Registry.registry_info(pkg_info).version_info))
           current_version = Pkg.project().version
-          
+
           @assert registered_version < current_version "Current version is not greater than the registered version"


### PR DESCRIPTION
## Summary

- Add `.github/actions/classify-pr` composite action that determines whether a PR is **substantive** (touches anything outside `.github/**`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`) or **non-substantive**.
- Wire it into the reusable `VersionCheck.yml` so non-substantive PRs log a skip message and exit 0 without running the real version comparison. Substantive PRs are unchanged.

## Motivation

Workflow-only PRs (e.g. dependabot updates to `.github/workflows/*.yml`) currently fail the required `Version Check / Check Versions` context because they don't bump the package version — even though a version bump is not appropriate for those changes. This lets them pass the required check without forcing an unrelated version bump.

## Test plan

- [ ] Merge and observe behavior on a subsequent workflow-only PR (e.g. future dependabot update) — should see `substantive=false` in the classify step and a "Skip version check" log message.
- [ ] Verify a regular code PR still runs the full version check against the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)