### PR TITLE
Fix composite-action reference path in VersionCheck

### DIFF
--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/classify-pr
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
         id: classify
 
       - name: "Skip version check on non-substantive PR"


### PR DESCRIPTION
## Summary

Change the composite-action reference in \`VersionCheck.yml\` from the local relative form \`./.github/actions/classify-pr\` to the full form \`ITensor/ITensorActions/.github/actions/classify-pr@main\`.

## Why

In a reusable workflow, \`uses: ./.github/actions/...\` resolves the relative path against the **caller's** checked-out workspace, not the reusable workflow's repository. That means every caller of \`VersionCheck.yml@main\` fails with:

\`\`\`
Can't find 'action.yml' ... under '/home/runner/work/<caller>/.github/actions/classify-pr'
\`\`\`

Observed on ITensor/SparseArraysBase.jl#169. The full \`owner/repo/path@ref\` form resolves against ITensorActions itself regardless of the caller.

## Test plan

- [ ] After merge, rerun VersionCheck on ITensor/SparseArraysBase.jl#169 and verify the classify step succeeds and the real version check is skipped (PR is non-substantive — only touches \`.github/workflows/IntegrationTest.yml\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)