### PR TITLE
Tests.yml: check compat upper bounds after instantiate

### DIFF
--- a/.github/actions/check-compat-bounds/action.yml
+++ b/.github/actions/check-compat-bounds/action.yml
@@ -1,0 +1,18 @@
+name: "Check compat upper bounds"
+description: "Fails if any package with a compat entry in the workspace is resolved to a version below the compat upper bound. Assumes the workspace has already been instantiated (e.g. via julia-actions/julia-buildpkg)."
+inputs:
+  workspace-root:
+    description: "Path to the workspace root (containing Project.toml and Manifest.toml)."
+    required: false
+    default: "."
+runs:
+  using: "composite"
+  steps:
+    - name: "Check compat upper bounds"
+      shell: bash
+      env:
+        WORKSPACE_ROOT: ${{ inputs.workspace-root }}
+        SCRIPT_PATH: ${{ github.action_path }}/check_compat_bounds.jl
+      run: |
+        set -euo pipefail
+        julia --color=yes "$SCRIPT_PATH" "$WORKSPACE_ROOT"

--- a/.github/actions/check-compat-bounds/check_compat_bounds.jl
+++ b/.github/actions/check-compat-bounds/check_compat_bounds.jl
@@ -1,0 +1,183 @@
+#!/usr/bin/env julia
+
+# Checks that every package with a compat entry across this workspace is
+# resolved to the highest registry version satisfying its compat spec. Fails
+# (exit 1) if any resolved version is below the maximum allowed by compat,
+# which typically indicates a transitive dependency is holding the workspace
+# back from its declared upper bound.
+#
+# Usage:
+#   julia check_compat_bounds.jl [workspace-root]
+#
+#   workspace-root : defaults to pwd()
+
+using Pkg
+using TOML
+
+function parse_args(args)
+    length(args) > 1 && error("Expected at most one argument; got $(length(args)): $args")
+    return abspath(isempty(args) ? pwd() : args[1])
+end
+
+const STDLIB_UUIDS = Set(keys(Pkg.Types.stdlibs()))
+is_stdlib(uuid::Base.UUID) = uuid in STDLIB_UUIDS
+
+function workspace_projects(root)
+    root_toml = joinpath(root, "Project.toml")
+    isfile(root_toml) || error("No Project.toml at $root")
+    proj = TOML.parsefile(root_toml)
+    tomls = [root_toml]
+    for rel in get(get(proj, "workspace", Dict{String,Any}()), "projects", String[])
+        candidate = joinpath(root, rel, "Project.toml")
+        if isfile(candidate)
+            push!(tomls, candidate)
+        elseif isfile(joinpath(root, rel))
+            push!(tomls, joinpath(root, rel))
+        else
+            @warn "Workspace project path does not exist: $rel"
+        end
+    end
+    return tomls
+end
+
+function collect_uuids(projects)
+    uuids = Dict{String,Base.UUID}()
+    for path in projects
+        proj = TOML.parsefile(path)
+        for key in ("deps", "weakdeps", "extras")
+            for (name, uuid_str) in get(proj, key, Dict{String,String}())
+                uuids[name] = Base.UUID(uuid_str)
+            end
+        end
+    end
+    return uuids
+end
+
+function collect_compat(projects, uuids)
+    entries = NamedTuple[]
+    for path in projects
+        proj = TOML.parsefile(path)
+        for (name, spec_str) in get(proj, "compat", Dict{String,String}())
+            name == "julia" && continue
+            uuid = get(uuids, name, nothing)
+            if uuid === nothing
+                @warn "Compat entry for '$name' in $path has no matching UUID in any workspace project's deps/weakdeps/extras; skipping."
+                continue
+            end
+            push!(entries, (; name, spec = spec_str, source = path, uuid))
+        end
+    end
+    return entries
+end
+
+function read_manifest(root)
+    manifest = joinpath(root, "Manifest.toml")
+    isfile(manifest) || error("No Manifest.toml at $root — run Pkg.instantiate() first.")
+    return TOML.parsefile(manifest)
+end
+
+function manifest_version(manifest, uuid::Base.UUID)
+    uuid_str = string(uuid)
+    # Julia 1.7+ manifest format nests packages under "deps"; older nests at top.
+    pkg_groups = get(manifest, "deps", manifest)
+    for (_, entries) in pkg_groups
+        entries isa AbstractVector || continue
+        for e in entries
+            e isa AbstractDict || continue
+            if get(e, "uuid", nothing) == uuid_str
+                v = get(e, "version", nothing)
+                return v === nothing ? nothing : VersionNumber(v)
+            end
+        end
+    end
+    return nothing
+end
+
+function registry_versions(uuid::Base.UUID)
+    versions = VersionNumber[]
+    for reg in Pkg.Registry.reachable_registries()
+        entry = get(reg.pkgs, uuid, nothing)
+        entry === nothing && continue
+        info = Pkg.Registry.registry_info(entry)
+        for (v, vinfo) in info.version_info
+            vinfo.yanked && continue
+            push!(versions, v)
+        end
+    end
+    return versions
+end
+
+function max_satisfying(versions, spec::Pkg.Types.VersionSpec)
+    m = nothing
+    for v in versions
+        v in spec || continue
+        (m === nothing || v > m) && (m = v)
+    end
+    return m
+end
+
+function main(args)
+    root = parse_args(args)
+    println("Checking compat upper bounds for workspace at: $root")
+
+    projects = workspace_projects(root)
+    println("Workspace projects:")
+    for p in projects
+        println("  - $(relpath(p, root))")
+    end
+
+    uuids = collect_uuids(projects)
+    entries = collect_compat(projects, uuids)
+    manifest = read_manifest(root)
+
+    issues = NamedTuple[]
+    for entry in entries
+        is_stdlib(entry.uuid) && continue
+
+        spec = try
+            Pkg.Types.semver_spec(entry.spec)
+        catch err
+            @warn "Could not parse compat spec '$(entry.spec)' for $(entry.name) in $(entry.source): $err"
+            continue
+        end
+
+        resolved = manifest_version(manifest, entry.uuid)
+        resolved === nothing && continue  # extras-only packages may not be resolved here
+
+        versions = registry_versions(entry.uuid)
+        isempty(versions) && continue  # unregistered (e.g. local [sources] deps)
+
+        max_allowed = max_satisfying(versions, spec)
+        if max_allowed === nothing
+            push!(issues, (; entry..., resolved, max_allowed, kind = :no_match))
+        elseif resolved < max_allowed
+            push!(issues, (; entry..., resolved, max_allowed, kind = :outdated))
+        end
+    end
+
+    if isempty(issues)
+        println()
+        println("All workspace compat entries are resolved to their highest allowed version.")
+        return 0
+    end
+
+    println()
+    println("Found $(length(issues)) compat entr$(length(issues) == 1 ? "y" : "ies") not matching the latest allowed version:")
+    println()
+    for i in issues
+        if i.kind == :outdated
+            println("  - $(i.name): resolved $(i.resolved), compat \"$(i.spec)\" allows up to $(i.max_allowed)")
+        else
+            println("  - $(i.name): compat \"$(i.spec)\" matches no registered version (resolved $(i.resolved))")
+        end
+        println("      declared in $(relpath(i.source, root))")
+    end
+    println()
+    println("This usually means a transitive dependency is pinning one of these packages to an older")
+    println("version than the compat entry allows. Either update the transitive dependency's compat,")
+    println("or tighten this package's compat to reflect what is actually being tested.")
+
+    return 1
+end
+
+exit(main(ARGS))

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -101,6 +101,11 @@ on:
         default: ""
         required: false
         type: string
+      check-compat-bounds:
+        description: "After instantiating, fail if any workspace compat entry is resolved to a version below its compat upper bound (indicates a transitive dependency is holding the workspace back from its declared bound)."
+        default: true
+        required: false
+        type: boolean
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -139,6 +144,12 @@ jobs:
         if: "${{ inputs.buildpkg }}"
         with:
           localregistry: "${{ inputs.localregistry }}"
+
+      - name: "Check compat upper bounds"
+        if: "${{ inputs.check-compat-bounds }}"
+        uses: ITensor/ITensorActions/.github/actions/check-compat-bounds@main
+        with:
+          workspace-root: "."
 
       - name: "Export extra environment variables"
         if: "${{ inputs.extra-env != '' }}"


### PR DESCRIPTION
Adds a new composite action `check-compat-bounds` that inspects a workspace's resolved manifest after `julia-actions/julia-buildpkg` and fails if any package with a compat entry is resolved to a version below the maximum allowed by its compat spec. This flags the common silent failure where a transitive dependency holds the workspace back from a compat upper bound the maintainer believes is being tested.

Tests.yml gains a `check-compat-bounds` input (default true) and runs the check between `julia-buildpkg` and `julia-runtest`. The same script can be invoked standalone (e.g. from a Jenkins job) by running `julia check_compat_bounds.jl <workspace-root>` after instantiating.