### PR TITLE
check-compat-bounds: add mode input (always | never | auto)

### DIFF
--- a/.github/actions/check-compat-bounds/action.yml
+++ b/.github/actions/check-compat-bounds/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Path to the workspace root (containing Project.toml and Manifest.toml)."
     required: false
     default: "."
+  mode:
+    description: "When to run the check. 'always' runs on every invocation. 'never' skips the check. 'auto' runs only when the PR author is a known dependency-update bot (CompatHelper, Dependabot). Matches the semantics of julia-actions/julia-runtest's `force_latest_compatible_version: auto`."
+    required: false
+    default: "always"
 runs:
   using: "composite"
   steps:
@@ -12,7 +16,35 @@ runs:
       shell: bash
       env:
         WORKSPACE_ROOT: ${{ inputs.workspace-root }}
+        MODE: ${{ inputs.mode }}
         SCRIPT_PATH: ${{ github.action_path }}/check_compat_bounds.jl
       run: |
         set -euo pipefail
-        julia --color=yes "$SCRIPT_PATH" "$WORKSPACE_ROOT"
+        case "$MODE" in
+          always)
+            run_check=true
+            ;;
+          never)
+            run_check=false
+            ;;
+          auto)
+            case "${GITHUB_ACTOR:-}" in
+              "github-actions[bot]"|"dependabot[bot]")
+                run_check=true
+                ;;
+              *)
+                run_check=false
+                ;;
+            esac
+            ;;
+          *)
+            echo "Unknown mode: '$MODE' (expected always | never | auto)." >&2
+            exit 2
+            ;;
+        esac
+
+        if [ "$run_check" = "true" ]; then
+          julia --color=yes "$SCRIPT_PATH" "$WORKSPACE_ROOT"
+        else
+          echo "Skipping compat-bounds check (mode=$MODE, actor=${GITHUB_ACTOR:-unset})."
+        fi

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -106,6 +106,11 @@ on:
         default: true
         required: false
         type: boolean
+      check-compat-bounds-mode:
+        description: "When to run the compat-bounds check: 'always' (every invocation), 'never' (skip), or 'auto' (run only when the PR author is CompatHelper or Dependabot). Matches julia-actions/julia-runtest's 'force_latest_compatible_version: auto' semantics."
+        default: "always"
+        required: false
+        type: string
     secrets:
       CODECOV_TOKEN:
         required: true
@@ -150,6 +155,7 @@ jobs:
         uses: ITensor/ITensorActions/.github/actions/check-compat-bounds@main
         with:
           workspace-root: "."
+          mode: "${{ inputs.check-compat-bounds-mode }}"
 
       - name: "Export extra environment variables"
         if: "${{ inputs.extra-env != '' }}"


### PR DESCRIPTION
## Summary

Follow-up to #62. Adds a `mode` input to the `check-compat-bounds` composite action and a matching `check-compat-bounds-mode` input to `Tests.yml`, controlling when the check runs.

## Rationale

The always-on default from #62 is the stringent position. Some maintainers may prefer to restrict the check to CompatHelper-style PRs, matching the behavior of [`julia-actions/julia-runtest`'s `force_latest_compatible_version: auto`](https://github.com/julia-actions/julia-runtest/blob/main/action.yml) — which, via [julia-runtest#144](https://github.com/julia-actions/julia-runtest/issues/144) and our own investigation, turns out to have scope limitations anyway (the sandbox is loaded from `test/Project.toml`, so root `[compat]` bumps aren't caught). This PR gives packages a knob to pick the tradeoff that fits them.

## Modes

- `always` (default): run on every invocation. Preserves #62's behavior.
- `never`: skip the check entirely.
- `auto`: run only when `$GITHUB_ACTOR` is a dependency-update bot — `github-actions[bot]` or `dependabot[bot]`.

## Test plan

- [x] Verified bash case-pattern quoting matches literal `[bot]` brackets (not treated as glob character class)
- [x] Pre-commit passes
- [ ] Observe behavior on a downstream package's CompatHelper PR vs a human PR (default `always` on both; `auto` should fire only on the bot PR)

## Rollout notes

Default stays `always` — this PR is purely additive. Downstream packages wanting the bot-only behavior can set `check-compat-bounds-mode: auto` in their `Tests.yml` caller.

Related:
- #62 (original check)
- [julia-actions/julia-runtest#144](https://github.com/julia-actions/julia-runtest/issues/144) (reports the symptom that motivated #62)
- [JuliaLang/Pkg.jl#3667](https://github.com/JuliaLang/Pkg.jl/issues/3667), [#3615](https://github.com/JuliaLang/Pkg.jl/pull/3615) (upstream Pkg discussion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)