### PR TITLE
VersionCheck: compare base branch instead of registry; drop @assert

### DIFF
--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       localregistry:
-        description: "Add local registries hosted on GitHub. Specified by providing the url (https/ssh) to the repositories as a newline (\n) seperated list. User is responsible for setting up the necessary SSH-Keys to access the repositories if necessary."
+        description: "Unused. Kept for backward compatibility with existing callers."
         default: ""
         required: false
         type: string
@@ -31,36 +31,54 @@ jobs:
           echo "PR classified as non-substantive (only .github/**, .pre-commit-config.yaml, .gitignore, LICENSE)."
           echo "No version bump is required. Reporting success without running the real check."
 
+      - name: "Fetch base branch"
+        if: steps.classify.outputs.substantive == 'true'
+        run: git fetch --depth=1 origin "${{ github.base_ref }}"
+
       - uses: julia-actions/setup-julia@v2
         if: steps.classify.outputs.substantive == 'true'
         with:
           version: ${{ inputs.julia-version }}
 
-      - uses: julia-actions/julia-buildpkg@latest
-        if: steps.classify.outputs.substantive == 'true'
-        with:
-          localregistry: "${{ inputs.localregistry }}"
-
-      - name: Check the Project version
+      - name: "Check version was bumped"
         if: steps.classify.outputs.substantive == 'true'
         shell: julia --color=yes {0}
         run: |
-          using Pkg
-          Pkg.activate(".")
+          using TOML
 
-          function find_pkg_info(uuid)
-              for registry in Pkg.Registry.reachable_registries()
-                  if haskey(registry.pkgs, uuid)
-                      return registry.pkgs[uuid]
-                  end
-              end
-              error("Package not found in any registry")
+          base_ref = ENV["GITHUB_BASE_REF"]
+          base_project_text = try
+              read(`git show "origin/$base_ref:Project.toml"`, String)
+          catch err
+              println("Could not read Project.toml on origin/$base_ref ($err); skipping check.")
+              exit(0)
+          end
+          base_project = TOML.parse(base_project_text)
+          current_project = TOML.parse(read("Project.toml", String))
+
+          if !haskey(base_project, "version")
+              println("Base branch Project.toml has no version field; skipping check.")
+              exit(0)
+          end
+          if !haskey(current_project, "version")
+              error(
+                  "Project.toml on this branch has no version field, but the base " *
+                  "branch ($base_ref) does. Restore the version field and bump it."
+              )
           end
 
-          uuid = Pkg.project().uuid
-          pkg_info = find_pkg_info(uuid)
+          base_version = VersionNumber(base_project["version"])
+          current_version = VersionNumber(current_project["version"])
 
-          registered_version = maximum(keys(Registry.registry_info(pkg_info).version_info))
-          current_version = Pkg.project().version
-
-          @assert registered_version < current_version "Current version is not greater than the registered version"
+          if current_version > base_version
+              println(
+                  "OK: Project.toml version bumped from $base_version " *
+                  "(origin/$base_ref) to $current_version (PR head)."
+              )
+          else
+              error(
+                  "Project.toml version was not bumped. Current version $current_version " *
+                  "is not greater than the version $base_version on the base branch " *
+                  "($base_ref). Bump the version in Project.toml."
+              )
+          end


### PR DESCRIPTION
## Summary

`VersionCheck` previously pulled the latest registered version from `ITensorRegistry` and asserted `registered_version < current_version`. That has a **design gap**: between a substantive PR merging (with a version bump) and the new version being registered, any number of further substantive PRs pass without bumping the version because `registered_version` is still the old value.

Concrete example seen on [ITensor/ITensorGaussianMPS.jl#24](https://github.com/ITensor/ITensorGaussianMPS.jl/pull/24):

| State | Registry | main `Project.toml` | PR `Project.toml` |
|---|---|---|---|
| Before #23 | 0.1.13 | 0.1.13 | — |
| #23 merged (not yet registered) | 0.1.13 | 0.1.14 | — |
| #24 opened | 0.1.13 | 0.1.14 | 0.1.14 (no bump) |

Old check: `0.1.13 < 0.1.14` → pass ✅. Reviewer intuition: ❌, the PR didn't move the version forward.

## Fix

Compare the current branch's `Project.toml` version against the **same file on the PR's base branch**. Answers the question reviewers actually have ("did this PR move the version forward relative to main"), removes the registration-timing dependency, and matches how General-registry tooling thinks about the check.

### Implementation

- New `Fetch base branch` step (`actions/checkout@v4` is shallow on PR head only; the base branch isn't otherwise available): `git fetch --depth=1 origin "$GITHUB_BASE_REF"`.
- Drop `julia-actions/julia-buildpkg` from this workflow — the new check only needs `TOML` (stdlib), not registry resolution.
- Use `TOML.parse` + `VersionNumber` + a real `if` / `error("…")` rather than `@assert`, so the failure produces a clean Julia error rather than an `AssertionError`. The error message spells out the base ref and both versions for actionable feedback.
- Skip gracefully when the base `Project.toml` is missing (initial-commit edge case) or when neither file has a `version` field. Error if only the PR removed the version field.

The `localregistry` input becomes unused but is kept (with an updated description) for backward compatibility with existing callers in ITensorPkgSkeleton-generated workflows.

## Test plan

- [ ] CI passes on this PR (substantive change, version field on both base and head — should report a clean pass message).
- [ ] Future PR opened that touches a substantive file but doesn't bump `Project.toml` version reports a clear failure message naming both versions.
- [ ] Workflow-only PRs (e.g. `.github/**`-only changes) still skip via the `classify-pr` action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)