### PR TITLE
Documentation.yml: add apt-packages, doc-prefix, extra-env inputs

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -51,6 +51,21 @@ on:
         description: "Prevent the workflow run from failing if/when the job fails"
         required: false
         type: boolean
+      apt-packages:
+        description: "Space-separated list of apt packages to install on Ubuntu runners before Julia setup (e.g. 'xvfb libgl1' for GUI-dependent documentation builds). Ignored on non-Linux runners."
+        default: ""
+        required: false
+        type: string
+      doc-prefix:
+        description: "Value prepended to each julia invocation in the workflow (both the project-setup step and the docs build step). Example: 'xvfb-run -a -s \"-screen 0 1024x768x24\" ' for packages whose precompile workload requires a display."
+        default: ""
+        required: false
+        type: string
+      extra-env:
+        description: "Multi-line KEY=VALUE pairs to export into the job's environment (via $GITHUB_ENV) before the setup and build steps."
+        default: ""
+        required: false
+        type: string
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -62,6 +77,13 @@ jobs:
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
     steps:
       - uses: actions/checkout@v4
+
+      - name: "Install apt packages"
+        if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ inputs.apt-packages }}
+
       - name: "Setup Julia ${{ inputs.julia-version }}"
         uses: julia-actions/setup-julia@v2
         with:
@@ -72,9 +94,16 @@ jobs:
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Setup project
-        shell: julia --project=docs --color=yes {0}
+      - name: "Export extra environment variables"
+        if: "${{ inputs.extra-env != '' }}"
+        shell: "bash"
         run: |
+          echo "${{ inputs.extra-env }}" >> "$GITHUB_ENV"
+
+      - name: Setup project
+        shell: "bash"
+        run: |
+          ${{ inputs.doc-prefix }}julia --project=docs --color=yes <<'EOF'
           import Pkg
           if VERSION >= v"1.8-"
             Pkg.Registry.add()
@@ -90,10 +119,11 @@ jobs:
           end
           Pkg.develop(Pkg.PackageSpec(path=pwd()))
           retry(Pkg.build)(verbose=true)
+          EOF
       - name: "Build and Deploy Documentation"
         env:
           GITHUB_TOKEN: ${{ inputs.github-token || secrets.GITHUB_TOKEN }}
-        run: ${{ inputs.debug-documenter && 'JULIA_DEBUG="Documenter"' || '' }} julia --project=docs/ ${{ inputs.coverage && '--code-coverage=user' }} docs/make.jl
+        run: ${{ inputs.debug-documenter && 'JULIA_DEBUG="Documenter"' || '' }} ${{ inputs.doc-prefix }}julia --project=docs/ ${{ inputs.coverage && '--code-coverage=user' }} docs/make.jl
 
       - uses: julia-actions/julia-processcoverage@v1
         if: "${{ inputs.coverage }}"

--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ jobs:
 | `coverage` | bool | `true` | Collect coverage from doctests and upload to Codecov. |
 | `coverage-directories` | string | `"src,ext"` | Comma-separated list of directories scanned by `julia-actions/julia-processcoverage`. |
 | `continue-on-error` | bool | `false` | Prevent the job from failing if the docs build fails. |
+| `apt-packages` | string | `""` | Space-separated apt packages to install on Ubuntu runners before Julia setup (e.g. `xvfb libgl1`). Ignored on non-Linux runners. |
+| `doc-prefix` | string | `""` | Prefix prepended to each `julia` invocation (both the project-setup step and the docs build step). Example: `xvfb-run -a -s "-screen 0 1024x768x24" ` for packages whose precompile workload requires a display. |
+| `extra-env` | string | `""` | Multi-line `KEY=VALUE` pairs exported into the job's environment (via `$GITHUB_ENV`) before the setup and build steps. |
 
 ### Secrets
 


### PR DESCRIPTION
## Summary

Mirrors the pattern added to the reusable `Tests.yml` in #61, so documentation builds for GUI-dependent packages (ITensorGLMakie, future Makie consumers) can use the shared workflow without needing a per-package custom `Documentation.yml`.

Three new optional inputs, all defaulting to off/empty so existing callers are unaffected:

- **`apt-packages`** — space-separated apt deps installed on Ubuntu runners before Julia setup. Guarded by `runner.os == 'Linux'`.
- **`doc-prefix`** — prepended to each julia invocation in the workflow (both the project-setup step and the docs build step). Callers set e.g. `"xvfb-run -a -s '-screen 0 1024x768x24' "` for packages whose precompile workload requires a display.
- **`extra-env`** — multi-line `KEY=VALUE` pairs written to `$GITHUB_ENV` before the setup/build steps.

### Minor structural change

The Setup project step changes from `shell: julia --project=docs --color=yes {0}` to `shell: bash` with a heredoc-piped julia invocation, so `doc-prefix` can be prepended. Behaviorally equivalent — the Pkg operations run identically. This matters because `Pkg.develop` / `Pkg.build` trigger auto-precompilation, which is where GLMakie's `__init__` fires and needs a display.

## Motivation

ITensorGLMakie.jl PR #20's docs build fails with:

```
GLMakie, LoadError: InitError: GLFW.GLFWError("X11: The DISPLAY environment variable is missing")
```

Without this extension, GLMakie-dependent docs builds can't use the shared workflow.