### PR TITLE
Tests.yml: run check-compat-bounds as a separate job

### DIFF
--- a/.github/actions/check-compat-bounds/check_compat_bounds.jl
+++ b/.github/actions/check-compat-bounds/check_compat_bounds.jl
@@ -53,6 +53,23 @@ function collect_uuids(projects)
     return uuids
 end
 
+# Versions declared by the workspace itself. A package bumping its own version
+# in a PR won't appear in the registry yet, so we merge these into the set of
+# candidate versions so in-workspace compat entries (e.g. a test/Project.toml
+# pinning the root package) don't spuriously fail the check.
+function workspace_versions(projects)
+    versions = Dict{Base.UUID,VersionNumber}()
+    for path in projects
+        proj = TOML.parsefile(path)
+        uuid_str = get(proj, "uuid", nothing)
+        version_str = get(proj, "version", nothing)
+        uuid_str === nothing && continue
+        version_str === nothing && continue
+        versions[Base.UUID(uuid_str)] = VersionNumber(version_str)
+    end
+    return versions
+end
+
 function collect_compat(projects, uuids)
     entries = NamedTuple[]
     for path in projects
@@ -129,6 +146,7 @@ function main(args)
     uuids = collect_uuids(projects)
     entries = collect_compat(projects, uuids)
     manifest = read_manifest(root)
+    ws_versions = workspace_versions(projects)
 
     issues = NamedTuple[]
     for entry in entries
@@ -145,6 +163,8 @@ function main(args)
         resolved === nothing && continue  # extras-only packages may not be resolved here
 
         versions = registry_versions(entry.uuid)
+        ws_version = get(ws_versions, entry.uuid, nothing)
+        ws_version === nothing || ws_version in versions || push!(versions, ws_version)
         isempty(versions) && continue  # unregistered (e.g. local [sources] deps)
 
         max_allowed = max_satisfying(versions, spec)

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -150,13 +150,6 @@ jobs:
         with:
           localregistry: "${{ inputs.localregistry }}"
 
-      - name: "Check compat upper bounds"
-        if: "${{ inputs.check-compat-bounds }}"
-        uses: ITensor/ITensorActions/.github/actions/check-compat-bounds@main
-        with:
-          workspace-root: "."
-          mode: "${{ inputs.check-compat-bounds-mode }}"
-
       - name: "Export extra environment variables"
         if: "${{ inputs.extra-env != '' }}"
         shell: "bash"
@@ -193,3 +186,44 @@ jobs:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"
           fail_ci_if_error: false
+
+  check-compat-bounds:
+    name: "Check compat bounds"
+    # Runs in parallel with `tests` so a compat-bound failure does not prevent
+    # the test matrix from executing. The caller's gate job (which `needs:` the
+    # reusable-workflow call) still aggregates both jobs, so a failure here
+    # blocks auto-merge.
+    #
+    # The check is platform-independent, so when the caller invokes this
+    # reusable workflow via a matrix (typical), we only run it on the canonical
+    # (ubuntu-latest, julia=1) cell to avoid running it N times.
+    if: >-
+      inputs.check-compat-bounds
+      && inputs.os == 'ubuntu-latest'
+      && inputs.julia-version == '1'
+      && (!github.event.pull_request.draft || inputs.run-all-on-draft)
+    runs-on: "ubuntu-latest"
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Setup Julia"
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: "1"
+
+      - uses: julia-actions/cache@v2
+        if: "${{ inputs.cache }}"
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - uses: julia-actions/julia-buildpkg@v1
+        if: "${{ inputs.buildpkg }}"
+        with:
+          localregistry: "${{ inputs.localregistry }}"
+
+      - name: "Check compat upper bounds"
+        uses: ITensor/ITensorActions/.github/actions/check-compat-bounds@main
+        with:
+          workspace-root: "."
+          mode: "${{ inputs.check-compat-bounds-mode }}"


### PR DESCRIPTION
## Summary

- Move the compat-bounds check out of the `tests` job into a sibling `check-compat-bounds` job in `Tests.yml`. A compat failure no longer prevents the test matrix from running, but still blocks auto-merge via the caller's gate job (which `needs:` the reusable-workflow call and so aggregates both jobs).
- Gate the new job to the canonical `(ubuntu-latest, julia=1)` cell so it runs exactly once per caller invocation regardless of matrix size, since the check is platform-independent.
- Fix `check_compat_bounds.jl` to not spuriously fail when a workspace project pins its own package to a not-yet-registered version.

## The self-compat bug

Reproduced in [ITensor/DataGraphs.jl#94](https://github.com/ITensor/DataGraphs.jl/pull/94):

```
Found 3 compat entries not matching the latest allowed version:
  - DataGraphs: compat "0.4" matches no registered version (resolved 0.4.0)
      declared in docs/Project.toml
  - DataGraphs: compat "0.4" matches no registered version (resolved 0.4.0)
      declared in examples/Project.toml
  - DataGraphs: compat "0.4" matches no registered version (resolved 0.4.0)
      declared in test/Project.toml
```

Root Project.toml bumps `version = "0.4.0"`; the workspace subprojects pin `DataGraphs = "0.4"`. Since no `0.4.x` is registered yet, `max_satisfying` returned `nothing` → `:no_match`.

The fix: `workspace_versions(projects)` reads each workspace Project.toml's `(uuid, version)`, and the main loop merges the workspace version into the candidate set before calling `max_satisfying`. Forward-looking self-compat entries that don't match the workspace version (e.g. declaring `= "0.5"` while root is still `0.4.0`) still fail as before.

## Caller impact

None. Existing callers of `ITensor/ITensorActions/.github/workflows/Tests.yml@main` don't need edits:
- The `check-compat-bounds` / `check-compat-bounds-mode` inputs are preserved with the same defaults.
- The caller's `tests-gate` job (`needs: tests`) automatically aggregates both reusable jobs — a new job inside the reusable bubbles up through the single `needs.tests.result`.

## Caveat

The canonical-cell gate assumes every caller's matrix includes `(ubuntu-latest, julia=1)`. Every ITensor package I looked at does. If that ever breaks down for some package we can swap the gate (e.g. to the lts cell) or expose an input.