### PR TITLE
Tests.yml: trivially-pass non-canonical check-compat-bounds cells

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -195,34 +195,46 @@ jobs:
     # blocks auto-merge.
     #
     # The check is platform-independent, so when the caller invokes this
-    # reusable workflow via a matrix (typical), we only run it on the canonical
-    # (ubuntu-latest, julia=1) cell to avoid running it N times.
+    # reusable workflow via a matrix (typical) we want the real work to run
+    # only once — on the canonical (ubuntu-latest, julia=1) cell. We gate each
+    # step with that condition rather than the job itself so non-canonical
+    # invocations resolve to a trivially-successful job instead of a skipped
+    # one (skipped jobs render as gray checks).
     if: >-
       inputs.check-compat-bounds
-      && inputs.os == 'ubuntu-latest'
-      && inputs.julia-version == '1'
       && (!github.event.pull_request.draft || inputs.run-all-on-draft)
     runs-on: "ubuntu-latest"
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
+      - name: "Skip (not canonical cell)"
+        if: "${{ inputs.os != 'ubuntu-latest' || inputs.julia-version != '1' }}"
+        run: |
+          echo "Compat-bounds check only runs on (ubuntu-latest, julia=1) per reusable-workflow invocation; this is ($OS, $VER)."
+        env:
+          OS: "${{ inputs.os }}"
+          VER: "${{ inputs.julia-version }}"
+
       - uses: actions/checkout@v4
+        if: "${{ inputs.os == 'ubuntu-latest' && inputs.julia-version == '1' }}"
 
       - name: "Setup Julia"
+        if: "${{ inputs.os == 'ubuntu-latest' && inputs.julia-version == '1' }}"
         uses: julia-actions/setup-julia@v2
         with:
           version: "1"
 
       - uses: julia-actions/cache@v2
-        if: "${{ inputs.cache }}"
+        if: "${{ inputs.os == 'ubuntu-latest' && inputs.julia-version == '1' && inputs.cache }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
       - uses: julia-actions/julia-buildpkg@v1
-        if: "${{ inputs.buildpkg }}"
+        if: "${{ inputs.os == 'ubuntu-latest' && inputs.julia-version == '1' && inputs.buildpkg }}"
         with:
           localregistry: "${{ inputs.localregistry }}"
 
       - name: "Check compat upper bounds"
+        if: "${{ inputs.os == 'ubuntu-latest' && inputs.julia-version == '1' }}"
         uses: ITensor/ITensorActions/.github/actions/check-compat-bounds@main
         with:
           workspace-root: "."


### PR DESCRIPTION
## Summary

Follow-up to #67. Avoid gray \"skipped\" `Check compat bounds` status checks on non-canonical matrix cells (observed on [ITensor/DataGraphs.jl#94](https://github.com/ITensor/DataGraphs.jl/pull/94)).

Before:

- Job-level `if:` gated the entire `check-compat-bounds` job on `(ubuntu-latest, julia=1)`.
- For a 6-cell caller matrix, 1 job ran the check, 5 jobs showed up as `skipped` (gray).

After:

- Job-level `if:` only gates on the global `check-compat-bounds` input + draft status — the job always materializes.
- Each step inside is gated on the canonical-cell condition.
- Non-canonical cells run one `echo` step and exit success → all 6 check-compat statuses are green, only one does real work.

## Trade-off

Each non-canonical invocation still provisions a runner (~15-30s) just to echo a line. That's a little wasteful vs. truly skipping the job, but I think it's worth it for the cleaner status view. If the runner overhead becomes a concern later, we can go back to job-level gating.

## Test plan

- [x] `pre-commit run --all-files` passes.
- [ ] After merge, retrigger a fresh run on a multi-cell caller (e.g. DataGraphs.jl#94) and confirm all 6 `Check compat bounds` checks are green rather than 1 green + 5 gray.

🤖 Generated with [Claude Code](https://claude.com/claude-code)