### PR TITLE
CheckCompatBounds: title-case the job display name

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -51,7 +51,7 @@ on:
 
 jobs:
   check-compat-bounds:
-    name: "Check compat bounds"
+    name: "Check Compat Bounds"
     if: "${{ !github.event.pull_request.draft || inputs.run-on-draft }}"
     runs-on: "ubuntu-latest"
     timeout-minutes: ${{ inputs.timeout-minutes }}


### PR DESCRIPTION
Tiny follow-up to #69. The reusable workflow's job `name:` was lowercase `"Check compat bounds"`; title-case it to produce a clean `"Check Compat Bounds / Check Compat Bounds"` status-check context for branch protection.