### PR TITLE
CompatHelper.yml: detect token owner so dedup works with COMPATHELPER_PAT

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -43,6 +43,18 @@ jobs:
           version = "3"
           Pkg.add(; name, uuid, version)
         shell: julia --color=yes {0}
+      - name: "Detect token owner"
+        # CompatHelper dedups open PRs by filtering on a fixed username
+        # ("github-actions[bot]" by default). When COMPATHELPER_PAT is used so
+        # pushes trigger CI, PRs are attributed to the PAT owner instead, so
+        # that filter silently drops its own PRs and every scheduled run opens
+        # a fresh duplicate. Detect the actual token owner and pass it through
+        # as the ci_cfg username so dedup works.
+        id: token-owner
+        run: |
+          echo "login=$(gh api user --jq .login)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.COMPATHELPER_PAT || secrets.GITHUB_TOKEN }}
       - name: "Run CompatHelper"
         run: |
           import CompatHelper
@@ -76,7 +88,10 @@ jobs:
             end
           end
           subdirs = ["", "docs", "examples", "test"]
-          CompatHelper.main(; registries, subdirs, bump_version=true)
+          ci_cfg = CompatHelper.GitHubActions(;
+            username="${{ steps.token-owner.outputs.login }}",
+          )
+          CompatHelper.main(ENV, ci_cfg; registries, subdirs, bump_version=true)
         shell: julia --color=yes {0}
         env:
           # Use COMPATHELPER_PAT if available so that pushes trigger CI workflows.

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -50,9 +50,15 @@ jobs:
         # that filter silently drops its own PRs and every scheduled run opens
         # a fresh duplicate. Detect the actual token owner and pass it through
         # as the ci_cfg username so dedup works.
+        #
+        # `gh api user` requires a user-scoped token; the built-in GITHUB_TOKEN
+        # is an installation token and will return 403. In that case we fall
+        # through to an empty value, and the Run step below leaves
+        # GitHubActions() at its `github-actions[bot]` default.
         id: token-owner
         run: |
-          echo "login=$(gh api user --jq .login)" >> "$GITHUB_OUTPUT"
+          login=$(gh api user --jq .login 2>/dev/null || echo "")
+          echo "login=$login" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.COMPATHELPER_PAT || secrets.GITHUB_TOKEN }}
       - name: "Run CompatHelper"
@@ -88,9 +94,10 @@ jobs:
             end
           end
           subdirs = ["", "docs", "examples", "test"]
-          ci_cfg = CompatHelper.GitHubActions(;
-            username="${{ steps.token-owner.outputs.login }}",
-          )
+          token_owner = "${{ steps.token-owner.outputs.login }}"
+          ci_cfg = isempty(token_owner) ?
+              CompatHelper.GitHubActions() :
+              CompatHelper.GitHubActions(; username=token_owner)
           CompatHelper.main(ENV, ci_cfg; registries, subdirs, bump_version=true)
         shell: julia --color=yes {0}
         env:


### PR DESCRIPTION
## Summary

Root-cause fix for the CompatHelper duplicate-PR explosion in the ITensor ecosystem.

## The bug

CompatHelper's "is there already an open PR for this bump?" filter
([`src/pull_requests.jl:53`](https://github.com/JuliaRegistries/CompatHelper.jl/blob/master/src/pull_requests.jl#L53))
matches PRs by a fixed username, defaulting to `github-actions[bot]`
([`src/utilities/ci.jl:10`](https://github.com/JuliaRegistries/CompatHelper.jl/blob/master/src/utilities/ci.jl#L10)).

This reusable workflow authenticates with `COMPATHELPER_PAT` when set, so
that pushes to the CompatHelper branch trigger CI (the built-in
`GITHUB_TOKEN` does not, by design). A PAT attributes the PR to the PAT
owner (in our case `mtfishman`), not the default `github-actions[bot]`.
CompatHelper's filter then silently drops its own prior PRs and every
scheduled run opens a fresh duplicate.

Across the ITensor org we accumulated **163 open CompatHelper PRs**. Biggest
offenders:

| Repo | Open PRs |
|---|---|
| FusionTensors.jl | 75 |
| TypeParameterAccessors.jl | 24 |
| FunctionImplementations.jl | 12 |
| NamedDimsArrays.jl | 12 |
| ITensorNetworks.jl | 10 |
| ITensorNetworksNext.jl | 9 |
| ITensorBase.jl | 6 |
| TensorAlgebra.jl | 6 |

Clusters of 6-15 PRs share identical titles and byte-for-byte-identical
diffs; they differ only in the timestamped branch name.

## The fix

Query the actual token owner via \`gh api user --jq .login\` at runtime and
pass it through as the \`username\` on \`CompatHelper.GitHubActions(; …)\`.
No hardcoding, no caller changes needed.

Fallback: \`gh api user\` requires a user-scoped token. The built-in
\`GITHUB_TOKEN\` is a GitHub App installation token and will return 403 on
that endpoint, so the detection step suppresses the error and falls through
to an empty login. When the login is empty the Julia step leaves
\`GitHubActions()\` at its default (\`github-actions[bot]\`), matching the
pre-patch behavior. So callers without a \`COMPATHELPER_PAT\` see no
change; callers with one get working dedup.

## Verification

Tested against TensorAlgebra.jl (6 identical open CompatHelper PRs) by
temporarily pointing its caller at this branch and triggering
`workflow_dispatch`. The run logged:

```
Info: An open PR with the title already exists
  new_pr_title = "CompatHelper: bump compat for StridedViews to 0.5, (keep existing compat)"
```

and finished without opening a 7th PR. Open CompatHelper PR count on
TensorAlgebra.jl remained 6.

Once this is merged, a separate backlog cleanup pass will bulk-close the
existing duplicates, keeping one PR per unique title. Tracked in
[`Projects/Ecosystem/compathelper_duplicate_prs/Overview.md`](https://github.com/ITensor/ITensorDevelopmentPlans)
in ITensorDevelopmentPlans.