### PR TITLE
CompatHelper.yml: cc @PAT-owner so author gets notifications

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -98,10 +98,19 @@ jobs:
           ci_cfg = isempty(token_owner) ?
               CompatHelper.GitHubActions() :
               CompatHelper.GitHubActions(; username=token_owner)
-          CompatHelper.main(ENV, ci_cfg; registries, subdirs, bump_version=true)
+          # cc_user posts "cc @$GITHUB_ACTOR" after opening the PR so the
+          # recipient gets a notification — otherwise, PRs authored via
+          # COMPATHELPER_PAT are authored as the PAT owner and GitHub
+          # doesn't notify them about their own PRs.
+          CompatHelper.main(ENV, ci_cfg; registries, subdirs, bump_version=true, cc_user=true)
         shell: julia --color=yes {0}
         env:
           # Use COMPATHELPER_PAT if available so that pushes trigger CI workflows.
           # The built-in GITHUB_TOKEN can't trigger other workflows
           # (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
           GITHUB_TOKEN: ${{ secrets.COMPATHELPER_PAT || secrets.GITHUB_TOKEN }}
+          # Target of the cc @mention. cc_user reads GITHUB_ACTOR, which on a
+          # scheduled run is unreliable (often github-actions[bot]). Override
+          # it with the PAT owner so the notification reaches the right user.
+          # Falls back to the actual workflow actor if detection failed.
+          GITHUB_ACTOR: ${{ steps.token-owner.outputs.login || github.actor }}


### PR DESCRIPTION
## Summary

Quick fix for a side effect of PR #71: with `COMPATHELPER_PAT` in use,
CompatHelper PRs are now authored by the PAT owner (\`mtfishman\`), and
GitHub doesn't generate notifications for you about your own PRs. The
maintainer sees them pile up silently.

Mitigation: enable CompatHelper's built-in \`cc_user\` option so it posts a
\`cc @\$GITHUB_ACTOR\` comment on each new PR — @mentions do notify even when
you are the author.

Also override \`GITHUB_ACTOR\` to the detected PAT owner. The default
\`GITHUB_ACTOR\` on a scheduled run is unreliable (typically
\`github-actions[bot]\`), so \`cc_user\` alone without the override would
mention the wrong account.

      \`workflow_dispatch\`) should post a \`cc @mtfishman\` comment on any
      newly created PR.

## Follow-up

This is the band-aid. The sustainable fix is a dedicated bot account for
CompatHelper, so PRs are authored by the bot and normal watcher
notifications work without a cc mention. Tracked separately.