### PR TITLE
Revert: CompatHelper cc @PAT-owner (self-mentions don't notify)

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -98,19 +98,10 @@ jobs:
           ci_cfg = isempty(token_owner) ?
               CompatHelper.GitHubActions() :
               CompatHelper.GitHubActions(; username=token_owner)
-          # cc_user posts "cc @$GITHUB_ACTOR" after opening the PR so the
-          # recipient gets a notification — otherwise, PRs authored via
-          # COMPATHELPER_PAT are authored as the PAT owner and GitHub
-          # doesn't notify them about their own PRs.
-          CompatHelper.main(ENV, ci_cfg; registries, subdirs, bump_version=true, cc_user=true)
+          CompatHelper.main(ENV, ci_cfg; registries, subdirs, bump_version=true)
         shell: julia --color=yes {0}
         env:
           # Use COMPATHELPER_PAT if available so that pushes trigger CI workflows.
           # The built-in GITHUB_TOKEN can't trigger other workflows
           # (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
           GITHUB_TOKEN: ${{ secrets.COMPATHELPER_PAT || secrets.GITHUB_TOKEN }}
-          # Target of the cc @mention. cc_user reads GITHUB_ACTOR, which on a
-          # scheduled run is unreliable (often github-actions[bot]). Override
-          # it with the PAT owner so the notification reaches the right user.
-          # Falls back to the actual workflow actor if detection failed.
-          GITHUB_ACTOR: ${{ steps.token-owner.outputs.login || github.actor }}


### PR DESCRIPTION
Reverts #72. Empirically verified that GitHub does not send notifications
for self-@mentions — posting \`cc @mtfishman\` on a PR authored by
\`mtfishman\` produces no notification. The proper fix is a dedicated bot
account for CompatHelper (tracked separately).