### PR TITLE
FormatCheck.yml: key concurrency group on PR number, not base ref

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -25,7 +25,12 @@ on:
         type: boolean
 
 concurrency:
-  group: "${{ inputs.concurrent-jobs && github.run_id || github.ref  }}:${{ github.workflow }}"
+  # Key on the PR number for `pull_request_target` events; `github.ref` would
+  # resolve to the target branch (`refs/heads/main`) and would put every PR's
+  # format check into the same group, causing each new PR to cancel all other
+  # in-progress format checks across the repo. Fall back to `github.ref` for
+  # non-PR triggers.
+  group: "${{ inputs.concurrent-jobs && github.run_id || github.event.pull_request.number || github.ref }}:${{ github.workflow }}"
   cancel-in-progress: ${{ !inputs.concurrent-jobs && inputs.cancel-in-progress }}
 
 jobs:


### PR DESCRIPTION
## Summary

Small bug in the shared \`FormatCheck.yml\` concurrency config. The group was:

\`\`\`yaml
concurrency:
  group: \"\${{ inputs.concurrent-jobs && github.run_id || github.ref }}:\${{ github.workflow }}\"
  cancel-in-progress: \${{ !inputs.concurrent-jobs && inputs.cancel-in-progress }}
\`\`\`

For \`pull_request_target\` events, \`github.ref\` is the target branch
(\`refs/heads/main\`), so every open PR's format check ended up in the same
concurrency group. With \`cancel-in-progress: true\`, whenever any PR triggered
a new format check, it cancelled in-progress format checks on all other PRs —
which is why PRs frequently show \"Format Check / Check Formatting: cancelled\"
for no visible reason.

Observed concretely on [ITensor/FunctionImplementations.jl#53](https://github.com/ITensor/FunctionImplementations.jl/pull/53):
the Format Check was cancelled when a different CompatHelper PR started a run
on the same repo.

## Fix

Key the group on \`github.event.pull_request.number\` when it's available, so
each PR has its own group. Fall back to \`github.ref\` for non-PR triggers
(e.g. scheduled or manual dispatch).