### PR TITLE
Tests.yml: disable force_latest_compatible_version on LTS

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -153,6 +153,13 @@ jobs:
           depwarn: "${{ inputs.julia-runtest-depwarn }}"
           coverage: "${{ inputs.coverage }}"
           prefix: "${{ inputs.test-prefix }}"
+          # On LTS, accept that newer dep versions may not be reachable —
+          # let Pkg resolve to whatever satisfies both the workspace compat
+          # and transitive constraints. `auto` (the default) would otherwise
+          # treat bot-authored bump PRs as failing whenever LTS can't reach
+          # the upper-end compat, even when we are fine with the bump being
+          # aspirational on LTS while working on current Julia.
+          force_latest_compatible_version: "${{ inputs.julia-version == 'lts' && 'false' || 'auto' }}"
         env:
           GROUP: "${{ inputs.group }}"
           JULIA_NUM_THREADS: "${{ inputs.nthreads }}"


### PR DESCRIPTION
## Summary

Skip \`force_latest_compatible_version\` on the LTS leg of the Tests matrix.
Keep the default (\`auto\`) on current Julia.

## Why

\`julia-actions/julia-runtest\`'s default is \`force_latest_compatible_version:
auto\`, which pins each dep to the upper end of its declared compat on bot-
authored PRs — so CompatHelper bumps are actually exercised against the new
version instead of resolving vacuously.

That's the correct behavior on current Julia. On LTS it produces spurious
failures whenever a transitive dep hasn't caught up. Concrete example:
[ITensorFormatter.jl#52](https://github.com/ITensor/ITensorFormatter.jl/pull/52)
widens \`JuliaSyntax\` compat to \`\"0.4.10, 1\"\`, but \`JuliaFormatter 2.3\`
(the only version compatible on LTS) pins JuliaSyntax to \`0.4.10\` — forcing
\`1\` on LTS makes it unsatisfiable. Tests on current Julia pass; tests on
LTS fail as unresolvable.

In many cases we're fine with a bump being aspirational on LTS while
working on current Julia. Without this change those PRs can never merge
unless the entire upstream LTS chain also catches up — which we can't
always control.

## Result

- **Current Julia**: \`auto\` as before — bump PRs still verified against the
  claimed latest version.
- **LTS**: resolves to whatever's reachable; tests still run, just not
  pinned to the upper-end compat.