### PR TITLE
check-compat-bounds: explain :outdated entries via resolver output

### DIFF
--- a/.github/actions/check-compat-bounds/check_compat_bounds.jl
+++ b/.github/actions/check-compat-bounds/check_compat_bounds.jl
@@ -133,6 +133,54 @@ function max_satisfying(versions, spec::Pkg.Types.VersionSpec)
     return m
 end
 
+# Best-effort explanation for an :outdated entry: try to add the target
+# version in a throwaway copy of the workspace and capture whatever the
+# resolver complains about. Returns a String (or "" if the attempt
+# unexpectedly succeeds / no useful output).
+function explain_outdated(workspace_root::String, dep_name::String, target::VersionNumber)
+    explanation = try
+        mktempdir() do tmp
+            # Copy only the TOML files (avoid copying .git, compiled artifacts, etc.).
+            # We don't need the package's src/ to re-resolve.
+            function copy_tomls(src, dst)
+                mkpath(dst)
+                for name in readdir(src; join = false)
+                    startswith(name, ".") && continue
+                    s = joinpath(src, name)
+                    d = joinpath(dst, name)
+                    if isdir(s)
+                        copy_tomls(s, d)
+                    elseif endswith(name, ".toml")
+                        cp(s, d; force = true)
+                    end
+                end
+            end
+            pkg_dir = joinpath(tmp, "pkg")
+            copy_tomls(workspace_root, pkg_dir)
+            # Pin `target` on a single version to force re-resolution.
+            # Capture stderr from a subprocess so the caller's environment is untouched.
+            spec_str = string(target)
+            io = IOBuffer()
+            cmd = `$(Base.julia_cmd()) --color=no --startup-file=no --project=$(pkg_dir) -e """
+                using Pkg
+                Pkg.add(Pkg.PackageSpec(name = \"$(dep_name)\", version = v\"$(spec_str)\"))
+            """`
+            proc = run(pipeline(ignorestatus(cmd); stdout = io, stderr = io))
+            output = String(take!(io))
+            if proc.exitcode == 0
+                return ""  # Unexpected success; nothing useful to report
+            end
+            # Trim to the interesting part: the Unsatisfiable-requirements block.
+            m = match(r"(Unsatisfiable requirements detected.*?)(?:\nStacktrace:|\z)"s, output)
+            return m === nothing ? strip(output) : strip(m.captures[1])
+        end
+    catch err
+        @warn "explain_outdated failed for $dep_name → $target" exception = (err, catch_backtrace())
+        ""
+    end
+    return explanation
+end
+
 function main(args)
     root = parse_args(args)
     println("Checking compat upper bounds for workspace at: $root")
@@ -191,6 +239,15 @@ function main(args)
             println("  - $(i.name): compat \"$(i.spec)\" matches no registered version (resolved $(i.resolved))")
         end
         println("      declared in $(relpath(i.source, root))")
+        if i.kind == :outdated
+            explanation = explain_outdated(root, i.name, i.max_allowed)
+            if !isempty(explanation)
+                println("      resolver output when forcing $(i.name) = $(i.max_allowed):")
+                for line in split(explanation, '\n')
+                    println("        ", line)
+                end
+            end
+        end
     end
     println()
     println("This usually means a transitive dependency is pinning one of these packages to an older")

--- a/.github/actions/check-compat-bounds/check_compat_bounds.jl
+++ b/.github/actions/check-compat-bounds/check_compat_bounds.jl
@@ -133,52 +133,21 @@ function max_satisfying(versions, spec::Pkg.Types.VersionSpec)
     return m
 end
 
-# Best-effort explanation for an :outdated entry: try to add the target
-# version in a throwaway copy of the workspace and capture whatever the
-# resolver complains about. Returns a String (or "" if the attempt
-# unexpectedly succeeds / no useful output).
-function explain_outdated(workspace_root::String, dep_name::String, target::VersionNumber)
-    explanation = try
+# Best-effort explanation for an :outdated entry: in a throwaway copy of
+# the workspace, force-pin the target version and return whatever the
+# resolver prints. The per-entry caller includes this in the report.
+function explain_outdated(workspace_root, dep_name, target::VersionNumber)
+    try
         mktempdir() do tmp
-            # Copy only the TOML files (avoid copying .git, compiled artifacts, etc.).
-            # We don't need the package's src/ to re-resolve.
-            function copy_tomls(src, dst)
-                mkpath(dst)
-                for name in readdir(src; join = false)
-                    startswith(name, ".") && continue
-                    s = joinpath(src, name)
-                    d = joinpath(dst, name)
-                    if isdir(s)
-                        copy_tomls(s, d)
-                    elseif endswith(name, ".toml")
-                        cp(s, d; force = true)
-                    end
-                end
-            end
             pkg_dir = joinpath(tmp, "pkg")
-            copy_tomls(workspace_root, pkg_dir)
-            # Pin `target` on a single version to force re-resolution.
-            # Capture stderr from a subprocess so the caller's environment is untouched.
-            spec_str = string(target)
-            io = IOBuffer()
-            cmd = `$(Base.julia_cmd()) --color=no --startup-file=no --project=$(pkg_dir) -e """
-                using Pkg
-                Pkg.add(Pkg.PackageSpec(name = \"$(dep_name)\", version = v\"$(spec_str)\"))
-            """`
-            proc = run(pipeline(ignorestatus(cmd); stdout = io, stderr = io))
-            output = String(take!(io))
-            if proc.exitcode == 0
-                return ""  # Unexpected success; nothing useful to report
-            end
-            # Trim to the interesting part: the Unsatisfiable-requirements block.
-            m = match(r"(Unsatisfiable requirements detected.*?)(?:\nStacktrace:|\z)"s, output)
-            return m === nothing ? strip(output) : strip(m.captures[1])
+            cp(workspace_root, pkg_dir; force = true)
+            cmd = `$(Base.julia_cmd()) --color=no --project=$(pkg_dir)
+                   -e "using Pkg; Pkg.add(Pkg.PackageSpec(name=\"$dep_name\", version=v\"$target\"))"`
+            return read(pipeline(ignorestatus(cmd); stderr = stdout), String)
         end
-    catch err
-        @warn "explain_outdated failed for $dep_name → $target" exception = (err, catch_backtrace())
+    catch
         ""
     end
-    return explanation
 end
 
 function main(args)


### PR DESCRIPTION
## Summary

When the compat-bounds check flags an `:outdated` entry (resolved version
below the declared upper bound), attempt to add the target version in a
throwaway copy of the workspace and capture the resolver output. Include
it in the per-entry report.

## Why

The current message tells you there's a gap but not why. The resolver already
knows why — it has the conflict graph — we just weren't surfacing it.

## Before vs after

Before:
```
- Runic: resolved 1.5.1, compat "1.5.1" allows up to 1.7.0
    declared in Project.toml
```

After:
```
- Runic: resolved 1.5.1, compat "1.5.1" allows up to 1.7.0
    declared in Project.toml
    resolver output when forcing Runic = 1.7.0:
      Unsatisfiable requirements detected for package JuliaSyntax:
       ├─restricted by JuliaFormatter 2.3.0 to 0.4.10
       └─Runic 1.7.0 requires JuliaSyntax ≥ 1 — no versions left
```

(The real output also includes some surrounding Julia process noise, e.g. stacktrace lines — not aggressively trimmed, to keep the implementation simple.)

Now you can see `JuliaFormatter` is the blocker, not Runic itself.

## Cost

One extra `Pkg.add` subprocess per flagged entry (~5-30s each). Runs only
when the check is already about to fail, so doesn't slow the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)