### PR TITLE
check-compat-bounds: trim Julia stacktrace from resolver output

### DIFF
--- a/.github/actions/check-compat-bounds/check_compat_bounds.jl
+++ b/.github/actions/check-compat-bounds/check_compat_bounds.jl
@@ -143,7 +143,11 @@ function explain_outdated(workspace_root, dep_name, target::VersionNumber)
             cp(workspace_root, pkg_dir; force = true)
             cmd = `$(Base.julia_cmd()) --color=no --project=$(pkg_dir)
                    -e "using Pkg; Pkg.add(Pkg.PackageSpec(name=\"$dep_name\", version=v\"$target\"))"`
-            return read(pipeline(ignorestatus(cmd); stderr = stdout), String)
+            buf = IOBuffer()
+            run(pipeline(ignorestatus(cmd); stdout = buf, stderr = buf))
+            output = String(take!(buf))
+            # Drop the Julia stacktrace; keep only the resolver's conflict log.
+            return strip(split(output, "\nStacktrace:"; limit = 2)[1])
         end
     catch
         ""


### PR DESCRIPTION
Follow-up to #76. Two issues:

1. **Stacktrace noise.** The captured resolver output included the Julia
   error stacktrace that follows \"Unsatisfiable requirements detected\". Trim
   everything from \`\\nStacktrace:\` onward.

2. **Bug in stderr capture.** The previous \`stderr = stdout\` redirect on the
   pipeline routed stderr to the parent process's stdout, not into the
   captured string — so \`read(pipeline(cmd), String)\` was returning empty
   and nothing was actually being reported. Switched to an IOBuffer with
   both streams merging into it.

After: the per-entry report shows only the relevant \`Unsatisfiable
requirements detected ...\` conflict log.