### PR TITLE
check-compat-bounds: resolve core-only, ignore weakdeps and subdirs

### DIFF
--- a/.github/actions/check-compat-bounds/check_compat_bounds.jl
+++ b/.github/actions/check-compat-bounds/check_compat_bounds.jl
@@ -1,10 +1,12 @@
 #!/usr/bin/env julia
 
-# Checks that every package with a compat entry across this workspace is
-# resolved to the highest registry version satisfying its compat spec. Fails
-# (exit 1) if any resolved version is below the maximum allowed by compat,
-# which typically indicates a transitive dependency is holding the workspace
-# back from its declared upper bound.
+# Checks that the root package's `[compat]` entries don't claim support for
+# versions the resolver can't actually reach. Resolves against the root
+# package in isolation — `[weakdeps]`, `[extras]`, and workspace sub-projects
+# (test/, docs/, examples/) are ignored. The primary claim a package makes is
+# about its core deps when installed on its own; if an extension or test-only
+# dep happens to constrain the workspace manifest, that's a secondary concern
+# that shouldn't block the core claim from being honest.
 #
 # Usage:
 #   julia check_compat_bounds.jl [workspace-root]
@@ -22,80 +24,43 @@ end
 const STDLIB_UUIDS = Set(keys(Pkg.Types.stdlibs()))
 is_stdlib(uuid::Base.UUID) = uuid in STDLIB_UUIDS
 
-function workspace_projects(root)
+# Build a standalone "core-only" copy of the root Project.toml at `dest`:
+# keep `[deps]` and `[compat]` (filtered to deps entries + `julia`); drop
+# `[weakdeps]`, `[extensions]`, `[extras]`, `[targets]`, and `[workspace]`.
+# Returns the parsed root project dict.
+function write_core_project(root, dest)
     root_toml = joinpath(root, "Project.toml")
     isfile(root_toml) || error("No Project.toml at $root")
     proj = TOML.parsefile(root_toml)
-    tomls = [root_toml]
-    for rel in get(get(proj, "workspace", Dict{String,Any}()), "projects", String[])
-        candidate = joinpath(root, rel, "Project.toml")
-        if isfile(candidate)
-            push!(tomls, candidate)
-        elseif isfile(joinpath(root, rel))
-            push!(tomls, joinpath(root, rel))
-        else
-            @warn "Workspace project path does not exist: $rel"
+    deps = get(proj, "deps", Dict{String, Any}())
+    compat = Dict{String, Any}()
+    for (name, spec) in get(proj, "compat", Dict{String, Any}())
+        if name == "julia" || haskey(deps, name)
+            compat[name] = spec
         end
     end
-    return tomls
-end
-
-function collect_uuids(projects)
-    uuids = Dict{String,Base.UUID}()
-    for path in projects
-        proj = TOML.parsefile(path)
-        for key in ("deps", "weakdeps", "extras")
-            for (name, uuid_str) in get(proj, key, Dict{String,String}())
-                uuids[name] = Base.UUID(uuid_str)
-            end
-        end
+    # Intentionally omit name/uuid/version so Pkg treats this as an anonymous
+    # environment, not a full package it should try to precompile.
+    core = Dict{String, Any}(
+        "deps" => deps,
+        "compat" => compat,
+    )
+    mkpath(dest)
+    open(joinpath(dest, "Project.toml"), "w") do io
+        return TOML.print(io, core; sorted = true)
     end
-    return uuids
+    return proj
 end
 
-# Versions declared by the workspace itself. A package bumping its own version
-# in a PR won't appear in the registry yet, so we merge these into the set of
-# candidate versions so in-workspace compat entries (e.g. a test/Project.toml
-# pinning the root package) don't spuriously fail the check.
-function workspace_versions(projects)
-    versions = Dict{Base.UUID,VersionNumber}()
-    for path in projects
-        proj = TOML.parsefile(path)
-        uuid_str = get(proj, "uuid", nothing)
-        version_str = get(proj, "version", nothing)
-        uuid_str === nothing && continue
-        version_str === nothing && continue
-        versions[Base.UUID(uuid_str)] = VersionNumber(version_str)
-    end
-    return versions
-end
-
-function collect_compat(projects, uuids)
-    entries = NamedTuple[]
-    for path in projects
-        proj = TOML.parsefile(path)
-        for (name, spec_str) in get(proj, "compat", Dict{String,String}())
-            name == "julia" && continue
-            uuid = get(uuids, name, nothing)
-            if uuid === nothing
-                @warn "Compat entry for '$name' in $path has no matching UUID in any workspace project's deps/weakdeps/extras; skipping."
-                continue
-            end
-            push!(entries, (; name, spec = spec_str, source = path, uuid))
-        end
-    end
-    return entries
-end
-
-function read_manifest(root)
-    manifest = joinpath(root, "Manifest.toml")
-    isfile(manifest) || error("No Manifest.toml at $root — run Pkg.instantiate() first.")
-    return TOML.parsefile(manifest)
+function instantiate_core(core_dir)
+    cmd = `$(Base.julia_cmd()) --color=no --startup-file=no --project=$(core_dir)
+           -e "using Pkg; Pkg.instantiate()"`
+    run(cmd)
+    return TOML.parsefile(joinpath(core_dir, "Manifest.toml"))
 end
 
 function manifest_version(manifest, uuid::Base.UUID)
     uuid_str = string(uuid)
-    # Julia 1.7+ manifest format nests packages under "deps"; older nests at top.
     pkg_groups = get(manifest, "deps", manifest)
     for (_, entries) in pkg_groups
         entries isa AbstractVector || continue
@@ -133,22 +98,17 @@ function max_satisfying(versions, spec::Pkg.Types.VersionSpec)
     return m
 end
 
-# Best-effort explanation for an :outdated entry: in a throwaway copy of
-# the workspace, force-pin the target version and return whatever the
-# resolver prints. The per-entry caller includes this in the report.
-function explain_outdated(workspace_root, dep_name, target::VersionNumber)
+# Best-effort explanation for an :outdated entry: in the already-prepared
+# core-only temp project, force-pin the target version and return whatever
+# the resolver prints (minus the Julia stacktrace).
+function explain_outdated(core_dir, dep_name, target::VersionNumber)
     try
-        mktempdir() do tmp
-            pkg_dir = joinpath(tmp, "pkg")
-            cp(workspace_root, pkg_dir; force = true)
-            cmd = `$(Base.julia_cmd()) --color=no --project=$(pkg_dir)
-                   -e "using Pkg; Pkg.add(Pkg.PackageSpec(name=\"$dep_name\", version=v\"$target\"))"`
-            buf = IOBuffer()
-            run(pipeline(ignorestatus(cmd); stdout = buf, stderr = buf))
-            output = String(take!(buf))
-            # Drop the Julia stacktrace; keep only the resolver's conflict log.
-            return strip(split(output, "\nStacktrace:"; limit = 2)[1])
-        end
+        cmd = `$(Base.julia_cmd()) --color=no --startup-file=no --project=$(core_dir)
+               -e "using Pkg; Pkg.add(Pkg.PackageSpec(name=\"$dep_name\", version=v\"$target\"))"`
+        buf = IOBuffer()
+        run(pipeline(ignorestatus(cmd); stdout = buf, stderr = buf))
+        output = String(take!(buf))
+        return strip(split(output, "\nStacktrace:"; limit = 2)[1])
     catch
         ""
     end
@@ -156,78 +116,74 @@ end
 
 function main(args)
     root = parse_args(args)
-    println("Checking compat upper bounds for workspace at: $root")
+    println("Checking compat upper bounds (core only) for: $root")
 
-    projects = workspace_projects(root)
-    println("Workspace projects:")
-    for p in projects
-        println("  - $(relpath(p, root))")
-    end
+    return mktempdir() do tmp
+        core_dir = joinpath(tmp, "core")
+        proj = write_core_project(root, core_dir)
+        manifest = instantiate_core(core_dir)
 
-    uuids = collect_uuids(projects)
-    entries = collect_compat(projects, uuids)
-    manifest = read_manifest(root)
-    ws_versions = workspace_versions(projects)
+        deps = get(proj, "deps", Dict{String, Any}())
+        compat = get(proj, "compat", Dict{String, Any}())
 
-    issues = NamedTuple[]
-    for entry in entries
-        is_stdlib(entry.uuid) && continue
+        issues = NamedTuple[]
+        for (name, spec_str) in compat
+            name == "julia" && continue
+            uuid_str = get(deps, name, nothing)
+            uuid_str === nothing && continue
+            uuid = Base.UUID(uuid_str)
+            is_stdlib(uuid) && continue
 
-        spec = try
-            Pkg.Types.semver_spec(entry.spec)
-        catch err
-            @warn "Could not parse compat spec '$(entry.spec)' for $(entry.name) in $(entry.source): $err"
-            continue
-        end
+            spec = try
+                Pkg.Types.semver_spec(spec_str)
+            catch err
+                @warn "Could not parse compat spec '$spec_str' for $name: $err"
+                continue
+            end
 
-        resolved = manifest_version(manifest, entry.uuid)
-        resolved === nothing && continue  # extras-only packages may not be resolved here
+            resolved = manifest_version(manifest, uuid)
+            resolved === nothing && continue
 
-        versions = registry_versions(entry.uuid)
-        ws_version = get(ws_versions, entry.uuid, nothing)
-        ws_version === nothing || ws_version in versions || push!(versions, ws_version)
-        isempty(versions) && continue  # unregistered (e.g. local [sources] deps)
+            versions = registry_versions(uuid)
+            isempty(versions) && continue
 
-        max_allowed = max_satisfying(versions, spec)
-        if max_allowed === nothing
-            push!(issues, (; entry..., resolved, max_allowed, kind = :no_match))
-        elseif resolved < max_allowed
-            push!(issues, (; entry..., resolved, max_allowed, kind = :outdated))
-        end
-    end
-
-    if isempty(issues)
-        println()
-        println("All workspace compat entries are resolved to their highest allowed version.")
-        return 0
-    end
-
-    println()
-    println("Found $(length(issues)) compat entr$(length(issues) == 1 ? "y" : "ies") not matching the latest allowed version:")
-    println()
-    for i in issues
-        if i.kind == :outdated
-            println("  - $(i.name): resolved $(i.resolved), compat \"$(i.spec)\" allows up to $(i.max_allowed)")
-        else
-            println("  - $(i.name): compat \"$(i.spec)\" matches no registered version (resolved $(i.resolved))")
-        end
-        println("      declared in $(relpath(i.source, root))")
-        if i.kind == :outdated
-            explanation = explain_outdated(root, i.name, i.max_allowed)
-            if !isempty(explanation)
-                println("      resolver output when forcing $(i.name) = $(i.max_allowed):")
-                for line in split(explanation, '\n')
-                    println("        ", line)
-                end
+            max_allowed = max_satisfying(versions, spec)
+            if max_allowed === nothing
+                push!(issues, (; name, spec = spec_str, resolved, max_allowed, kind = :no_match))
+            elseif resolved < max_allowed
+                push!(issues, (; name, spec = spec_str, resolved, max_allowed, kind = :outdated))
             end
         end
-    end
-    println()
-    println("This usually means a transitive dependency is pinning one of these packages to an older")
-    println("version than the compat entry allows. Either update the transitive dependency's compat,")
-    println("or tighten this package's compat to reflect what is actually being tested.")
 
-    return 1
+        if isempty(issues)
+            println()
+            println("All core compat entries are resolved to their highest allowed version.")
+            return 0
+        end
+
+        println()
+        println("Found $(length(issues)) compat entr$(length(issues) == 1 ? "y" : "ies") not matching the latest allowed version:")
+        println()
+        for i in issues
+            if i.kind == :outdated
+                println("  - $(i.name): resolved $(i.resolved), compat \"$(i.spec)\" allows up to $(i.max_allowed)")
+                explanation = explain_outdated(core_dir, i.name, i.max_allowed)
+                if !isempty(explanation)
+                    println("      resolver output when forcing $(i.name) = $(i.max_allowed):")
+                    for line in split(explanation, '\n')
+                        println("        ", line)
+                    end
+                end
+            else
+                println("  - $(i.name): compat \"$(i.spec)\" matches no registered version (resolved $(i.resolved))")
+            end
+        end
+        println()
+        println("Narrow the package's own `[compat]` to match what the resolver reaches,")
+        println("or widen the upstream constraint that is holding it back.")
+
+        return 1
+    end
 end
 
 exit(main(ARGS))


### PR DESCRIPTION
## Summary

Rewrite \`check_compat_bounds.jl\` to resolve the root package's \`[deps]\` in an anonymous environment — no \`[weakdeps]\`, no \`[extras]\`, no \`[workspace]\` sub-projects — and compare each compat entry against that core resolution.

## Why

The primary claim a package makes is "I work with the latest versions of my core deps." Extensions, test-only deps, and docs-only deps are secondary. Under the old check, a weakdep's transitive constraint (or a test dep's) could pin a core dep below its declared upper bound and produce an aspirational-claim failure — even though users installing the package on its own would be fine. The only remedies were local narrowings (lying about what the package supports) or removing the weakdep.

## Concrete example

\`ITensorNetworks\` has \`EinExprs\` as a weakdep. \`EinExprs\` caps \`DataStructures\` at \`0.18\`, which in turn caps \`Graphs\` at \`1.13\` and \`OMEinsumContractionOrders\` at \`1.2.2\`. Under the old check, all three were flagged as aspirational — forcing either EinExprs removal or three compat narrowings in ITN. Under the new check, ITN's core resolution doesn't include EinExprs, so all three resolve at their declared upper bounds; whether the extension \*also\* works at those upper bounds is left for whoever cares about that extension.

Verified locally: after this change, ITN main passes \`check_compat_bounds.jl\` with no flags. ITensorFormatter and FusionTensors still flag correctly because their blockers are in \`[deps]\` (not weakdeps).

## Breaking changes for users of the check

- Compat entries for packages listed in \`[weakdeps]\` or \`[extras]\` are no longer checked.
- Entries in \`test/Project.toml\`, \`docs/Project.toml\`, \`examples/Project.toml\` are also no longer checked.
- The \`workspace_versions\` self-compat fix (ITensorActions#67) is gone. Wasn't needed once subdir projects are ignored.

The check is strictly less pedantic than before. PRs that were passing will continue to pass; some that were failing will start to pass.