### PR TITLE
IntegrationTest: catch ResolverError for URL-based downstreams

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -79,15 +79,15 @@ jobs:
             end
           end
           pkg = "${{ inputs.pkg }}"
-          if startswith(pkg, "https://") || startswith(pkg, "git@")
-            # URL: unregistered or private package, skip version-pinning.
-            pkg_name = replace(basename(pkg), r"\.jl$" => "")
-            Pkg.add(PackageSpec(; url=pkg))
-            Pkg.develop(PackageSpec(; path="."))
-            Pkg.update()
-            Pkg.test(PackageSpec(; name=pkg_name))
-          else
-            try
+          try
+            if startswith(pkg, "https://") || startswith(pkg, "git@")
+              # URL: unregistered or private package, skip version-pinning.
+              pkg_name = replace(basename(pkg), r"\.jl$" => "")
+              Pkg.add(PackageSpec(; url=pkg))  # resolver may fail with main deps
+              Pkg.develop(PackageSpec(; path="."))  # resolver may fail with main deps
+              Pkg.update()
+              Pkg.test(PackageSpec(; name=pkg_name))  # resolver may fail with test time deps
+            else
               Pkg.add(PackageSpec(; name=pkg))
               # Determine the version that gets installed in order to detect
               # if the package is forced to downgrade.
@@ -100,12 +100,12 @@ jobs:
               # to see if there is a compatibility issue.
               Pkg.add(PackageSpec(; name=pkg, version=version))
               Pkg.test(PackageSpec(; name=pkg))  # resolver may fail with test time deps
-            catch err
-              err isa Pkg.Resolve.ResolverError || rethrow()
-              # If we can't resolve that means this is incompatible by SemVer and this is fine
-              # It means we marked this as a breaking change, so we don't need to worry about
-              # Mistakenly introducing a breaking change, as we have intentionally made one
-              @info "Not compatible with this release. No problem." exception=err
-              exit(0)  # Exit immediately, as a success
             end
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine
+            # It means we marked this as a breaking change, so we don't need to worry about
+            # Mistakenly introducing a breaking change, as we have intentionally made one
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
           end


### PR DESCRIPTION
## Summary
The `try/catch Pkg.Resolve.ResolverError` wrapper was only around the registered-package branch of `IntegrationTest.yml`. URL-based downstreams (unregistered / private packages specified as `https://...` or `git@...`) ran `Pkg.add(url=pkg)` / `Pkg.develop(".")` / `Pkg.update()` with no error handling, so a breaking change in the PR that the downstream's compat didn't allow failed the job instead of being reported as an intentional SemVer-breaking change.

This PR hoists the existing `try/catch` up to cover the full `if/else`, so both branches share one resolver-error exit (the "not compatible with this release — no problem" path). No other behavior changes.

Surfaced by [ITensor/ITensorNetworks.jl#327](https://github.com/ITensor/ITensorNetworks.jl/pull/327), where the Tennis.jl downstream (passed as a URL) failed with `ResolverError` after the PR bumped ITensorNetworks to 0.16.0.