### PR TITLE
FormatPullRequest + Registrator: set peter-evans author and committer to PAT owner

### DIFF
--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -79,12 +79,12 @@ jobs:
             echo "changes=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Resolve the PAT owner so commit author and reaction attribution match
-      # the identity the token is actually authenticating as. Falls back to
-      # github-actions[bot] if FORMATPULLREQUEST_PAT is unset (e.g. forks).
+      # Resolve the PAT owner so commit author, PR committer, and reaction
+      # attribution all match the identity the token authenticates as.
+      # Falls back to github-actions[bot] when FORMATPULLREQUEST_PAT is
+      # unset (forks, etc.).
       - name: Detect token owner
         id: token-owner
-        if: github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ secrets.FORMATPULLREQUEST_PAT || secrets.GITHUB_TOKEN }}
         shell: bash
@@ -92,23 +92,25 @@ jobs:
           json=$(gh api user 2>/dev/null || echo '{}')
           login=$(echo "$json" | jq -r '.login // ""')
           id=$(echo "$json" | jq -r '.id // ""')
-          echo "login=$login" >> "$GITHUB_OUTPUT"
-          echo "id=$id" >> "$GITHUB_OUTPUT"
+          if [ -n "$login" ]; then
+            name="$login"
+            email="${id}+${login}@users.noreply.github.com"
+          else
+            name="github-actions[bot]"
+            email="github-actions[bot]@users.noreply.github.com"
+          fi
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "email=$email" >> "$GITHUB_OUTPUT"
 
       # issue_comment mode: commit directly to the PR branch
       - name: Commit and push changes
         if: github.event_name == 'issue_comment' && steps.changes.outputs.changes == 'true'
         env:
-          TOKEN_LOGIN: ${{ steps.token-owner.outputs.login }}
-          TOKEN_ID: ${{ steps.token-owner.outputs.id }}
+          GIT_NAME: ${{ steps.token-owner.outputs.name }}
+          GIT_EMAIL: ${{ steps.token-owner.outputs.email }}
         run: |
-          if [ -n "$TOKEN_LOGIN" ]; then
-            git config user.name "$TOKEN_LOGIN"
-            git config user.email "${TOKEN_ID}+${TOKEN_LOGIN}@users.noreply.github.com"
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-          fi
+          git config user.name "$GIT_NAME"
+          git config user.email "$GIT_EMAIL"
           git add -A
           git commit -m "Format .jl files (ITensorFormatter)"
           git push
@@ -148,6 +150,8 @@ jobs:
           title: "Automatic ITensorFormatter run"
           branch: auto-format-pr
           delete-branch: true
+          author: "${{ steps.token-owner.outputs.name }} <${{ steps.token-owner.outputs.email }}>"
+          committer: "${{ steps.token-owner.outputs.name }} <${{ steps.token-owner.outputs.email }}>"
 
       - name: Check outputs
         if: github.event_name != 'issue_comment'

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -263,6 +263,30 @@ jobs:
           path: registry
           token: "${{ secrets.REGISTRATOR_PAT }}"
 
+      # Resolve the PAT owner so the registry-PR commit author and committer
+      # both match the authenticating identity. Without this, peter-evans
+      # below defaults the author to the workflow-trigger commit author and
+      # the committer to github-actions[bot].
+      - name: Detect token owner
+        if: steps.meta.outputs.route == 'local'
+        id: token-owner
+        env:
+          GH_TOKEN: ${{ secrets.REGISTRATOR_PAT }}
+        shell: bash
+        run: |
+          json=$(gh api user 2>/dev/null || echo '{}')
+          login=$(echo "$json" | jq -r '.login // ""')
+          id=$(echo "$json" | jq -r '.id // ""')
+          if [ -n "$login" ]; then
+            name="$login"
+            email="${id}+${login}@users.noreply.github.com"
+          else
+            name="github-actions[bot]"
+            email="github-actions[bot]@users.noreply.github.com"
+          fi
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "email=$email" >> "$GITHUB_OUTPUT"
+
       - name: Compose PR metadata (local registry)
         if: steps.meta.outputs.route == 'local'
         id: local_pr
@@ -319,6 +343,8 @@ jobs:
           body: "${{ steps.local_pr.outputs.body }}"
           token: "${{ secrets.REGISTRATOR_PAT }}"
           delete-branch: true
+          author: "${{ steps.token-owner.outputs.name }} <${{ steps.token-owner.outputs.email }}>"
+          committer: "${{ steps.token-owner.outputs.name }} <${{ steps.token-owner.outputs.email }}>"
 
       - name: Summary (Local registry)
         if: steps.meta.outputs.route == 'local'


### PR DESCRIPTION
## Summary

`peter-evans/create-pull-request@v7` defaults to:

- `author` = the workflow-trigger's commit author
- `committer` = `github-actions[bot]`

With the PAT-owned automation model, that produces split-identity commits like **"mtfishman authored and github-actions[bot] committed"** on Registrator's registry PRs and FormatPullRequest's scheduled auto-format PRs. Intent is pure automation; display is half-human.

This PR resolves the PAT owner at runtime (reusing the existing `Detect token owner` pattern from `CompatHelper.yml` and the pre-existing `issue_comment` branch of `FormatPullRequest.yml`) and passes explicit `author` and `committer` inputs to `peter-evans/create-pull-request` equal to that owner's identity. When `author == committer`, GitHub renders the commit with a single author.

## Scope

- `FormatPullRequest.yml`:
  - Drop the `if: github.event_name == 'issue_comment'` guard on the `Detect token owner` step so its outputs are available to the scheduled path as well.
  - Pass `author` / `committer` to `peter-evans/create-pull-request@v7` (scheduled path).
  - Simplify the commit-and-push step (issue_comment path) to use the new `name` / `email` outputs.
- `Registrator.yml`:
  - Add a `Detect token owner` step (conditional on local-registry path).
  - Pass `author` / `committer` to `peter-evans/create-pull-request@v7` (local path).

Falls back to `github-actions[bot]` when the relevant PAT is unset (forks, etc.).

## Out of scope

Registrator's General-path commit-comment (the one that mentions Julia's registration bot) and the final reaction step still use \`GITHUB_TOKEN\` → \`github-actions[bot]\`. Swapping them requires expanding \`REGISTRATOR_PAT\`'s scope beyond \`ITensor/ITensorRegistry\`; tracked separately.