### PR TITLE
Registrator: use REGISTRATOR_PAT for General-path comment and reaction

### DIFF
--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -218,7 +218,7 @@ jobs:
         id: cc
         uses: peter-evans/commit-comment@v4
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.REGISTRATOR_PAT || github.token }}
           sha: ${{ env.TARGET_SHA }}
           body-path: registrator-comment.md
 
@@ -365,7 +365,7 @@ jobs:
       - name: React to comment
         if: github.event_name == 'issue_comment'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REGISTRATOR_PAT || secrets.GITHUB_TOKEN }}
         run: |
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             --method POST -f content='+1'


### PR DESCRIPTION
## Summary

Two call sites in `Registrator.yml` previously used `GITHUB_TOKEN`, so they were attributed to `github-actions[bot]` regardless of who owned `REGISTRATOR_PAT`:

1. The General-path `peter-evans/commit-comment@v4` step that posts the trigger comment for Julia's registration bot.
2. The final `+1` reaction step on the triggering `/register` comment.

With `REGISTRATOR_PAT`'s scope broadened from `ITensor/ITensorRegistry`-only to all org repos + Issues: r/w, both calls can now use the PAT. Both fall back to `GITHUB_TOKEN` when `REGISTRATOR_PAT` isn't set (forks, outside the ITensor org).

## Scope

`.github/workflows/Registrator.yml` only.