### PR TITLE
FormatCheck + IntegrationTestRequest: attribute comments to the PAT owner

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -101,14 +101,15 @@ jobs:
         uses: peter-evans/find-comment@v3
         id: find-comment
         with:
+          token: ${{ secrets.FORMATPULLREQUEST_PAT || github.token }}
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
           body-includes: '<!-- format-check-summary -->'
 
       - name: Comment formatting suggestions
         if: steps.format.outputs.exit_code == 1
         uses: peter-evans/create-or-update-comment@v4
         with:
+          token: ${{ secrets.FORMATPULLREQUEST_PAT || github.token }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
@@ -131,6 +132,7 @@ jobs:
         if: steps.format.outputs.exit_code == 0 && steps.find-comment.outputs.comment-id
         uses: peter-evans/create-or-update-comment@v4
         with:
+          token: ${{ secrets.FORMATPULLREQUEST_PAT || github.token }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -49,5 +49,6 @@ jobs:
     steps:
       - uses: peter-evans/create-or-update-comment@v4
         with:
+          token: ${{ secrets.INTEGRATIONTEST_PAT || github.token }}
           comment-id: ${{ github.event.comment.id }}
           reactions: '+1'


### PR DESCRIPTION
## Summary

Two workflows posted comments via the default `GITHUB_TOKEN`, attributing them to `github-actions[bot]` regardless of whether `FORMATPULLREQUEST_PAT` or `INTEGRATIONTEST_PAT` was set.

- `FormatCheck.yml` now passes `FORMATPULLREQUEST_PAT` (with `github.token` fallback) to the `peter-evans/find-comment@v3` and two `peter-evans/create-or-update-comment@v4` steps. Also drops the `comment-author: 'github-actions[bot]'` hardcoded filter on find-comment — the `<!-- format-check-summary -->` HTML-comment marker is specific enough on its own, and keeping the hardcoded author filter means future PAT-owner runs never find their own previous comment and spam duplicates on long-lived PRs.
- `IntegrationTestRequest.yml` passes `INTEGRATIONTEST_PAT` (with `github.token` fallback) to its `+1` reaction step so the reaction is attributed consistently with the rest of the ecosystem automation.

Both fall back to `GITHUB_TOKEN` when the relevant PAT is unset (forks, etc.).