### PR TITLE
TagBot: add `subdirs` input to tag packages in subdirectories

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -2,6 +2,12 @@ name: "Reusable TagBot Workflow"
 
 on:
   workflow_call:
+    inputs:
+      subdirs:
+        description: "JSON array of subdir package names, e.g. '[\"NDTensors\"]'"
+        required: false
+        default: "[]"
+        type: "string"
     secrets:
       TAGBOT_PAT:
         required: false
@@ -20,3 +26,15 @@ jobs:
       - uses: "JuliaRegistries/TagBot@v1"
         with:
           token: "${{ secrets.TAGBOT_PAT || github.token }}"
+  TagBotGeneralSubdirs:
+    if: "${{ inputs.subdirs != '[]' }}"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        subdir: "${{ fromJSON(inputs.subdirs) }}"
+    steps:
+      - uses: "JuliaRegistries/TagBot@v1"
+        with:
+          token: "${{ secrets.TAGBOT_PAT || github.token }}"
+          subdir: "${{ matrix.subdir }}"

--- a/README.md
+++ b/README.md
@@ -657,10 +657,12 @@ jobs:
 ## TagBot
 
 The TagBot workflow creates GitHub releases and tags whenever a new version of a package
-is registered in a Julia registry. It runs two jobs in parallel — one scanning
+is registered in a Julia registry. It runs separate jobs in parallel — one scanning
 [ITensorRegistry](https://github.com/ITensor/ITensorRegistry) and one scanning the
 [General registry](https://github.com/JuliaRegistries/General) — so a package registered
-in either registry is handled automatically.
+in either registry is handled automatically. For repositories that contain additional
+Julia packages in subdirectories (for example a monorepo layout), an opt-in `subdirs`
+input adds matrix jobs that tag those subdir packages from the General registry.
 
 ### How triggering works
 
@@ -715,6 +717,44 @@ comment would be simpler, but [ITensorFormatter](https://github.com/ITensor/ITen
 comments (tracked upstream at
 [YAML.jl#245](https://github.com/JuliaData/YAML.jl/issues/245)). So the marker has to
 live in a structural element instead of a `#` line.
+
+### Tagging packages in subdirectories
+
+Some repositories ship more than one Julia package — for example, a top-level
+package plus one or more sub-packages under their own subdirectories. Each
+sub-package is registered separately in the General registry and gets its own
+tag namespace (`SubPkgName-vX.Y.Z`).
+
+The reusable workflow handles these via the optional `subdirs` input, which
+takes a JSON-encoded array of subdirectory package names and runs an additional
+matrix job per entry, passing each name to TagBot's `subdir` parameter:
+
+```yaml
+name: "TagBot"
+on:
+  issue_comment:
+    types:
+      - "created"
+  workflow_dispatch: ~
+env:
+  REGISTRY_TAGBOT_ACTION: "JuliaRegistries/TagBot"
+jobs:
+  TagBot:
+    if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
+    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@main"
+    with:
+      subdirs: '["NDTensors"]'
+    secrets: inherit
+```
+
+When `subdirs` is left at its default of `'[]'`, the matrix job is skipped and
+the workflow behaves exactly as before — only top-level packages are tagged.
+
+### Inputs
+
+| Input | Type | Default | Description |
+|---|---|---|---|
+| `subdirs` | string | `"[]"` | JSON-encoded array of subdirectory package names to tag from the General registry, e.g. `'["NDTensors"]'`. Each entry is passed as the `subdir` parameter to a matrix job invoking `JuliaRegistries/TagBot`. Leave at the default to skip subdir tagging. |
 
 ### Secrets
 


### PR DESCRIPTION
## Summary

The reusable TagBot workflow previously called `JuliaRegistries/TagBot@v1` without a `subdir` parameter, so packages registered as subdirectories of their host repo (for example `NDTensors` inside `ITensors.jl`) were never tagged. After each General registry merge for a subdir package, `JuliaTagBot` re-posts an `expected a tag to exist by now` notification on the trigger issue indefinitely (motivating example: [ITensor/ITensors.jl#1731](https://github.com/ITensor/ITensors.jl/issues/1731)).

This PR adds opt-in subdir support without changing behavior for any existing caller:

- New `subdirs` `workflow_call` input — a JSON-encoded array of subdirectory package names, e.g. `'["NDTensors"]'`. Default `'[]'`.
- New `TagBotGeneralSubdirs` job — runs as a matrix over `fromJSON(inputs.subdirs)`, passing each entry as the `subdir` parameter to `JuliaRegistries/TagBot@v1`. Gated on `${{ inputs.subdirs != '[]' }}`, so it is skipped entirely for callers that don't set the input.
- Existing `TagBotITensorRegistry` and `TagBotGeneral` jobs are unchanged.

Subdir support is intentionally limited to the General-registry path. ITensorRegistry currently has no subdir packages, so `TagBotITensorRegistry` is left untouched and can be extended the same way if that changes.

A caller opts in by adding `with: { subdirs: '["PkgName"]' }` to its `TagBot.yml`. See the new "Tagging packages in subdirectories" section in the README for an example.