### PR TITLE
TagBot: tag subdir packages at the registered commit

### DIFF
--- a/.github/actions/tag-subdir/action.yml
+++ b/.github/actions/tag-subdir/action.yml
@@ -1,0 +1,32 @@
+name: "Tag a subdir package at the registered commit"
+description: "Creates missing tags and GitHub releases for a subdir package using the commit recorded in each version's General-registry PR. Replaces JuliaRegistries/TagBot's subdir handling, which uses a tree-hash fast-path that picks a later same-subtree commit instead of the registered one."
+inputs:
+  subdir:
+    description: "Subdir of the package within this repo, e.g. NDTensors."
+    required: true
+  package-name:
+    description: "Registered package name. Defaults to the subdir, which is the convention in this ecosystem."
+    required: false
+    default: ""
+  dry-run:
+    description: "If true, log decisions without creating tags or releases."
+    required: false
+    default: "false"
+  token:
+    description: "GitHub token used for API calls. Needs contents: write to create tags and releases."
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: "composite"
+  steps:
+    - name: "Tag ${{ inputs.subdir }}"
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        TAG_SUBDIR: ${{ inputs.subdir }}
+        TAG_PACKAGE_NAME: ${{ inputs.package-name }}
+        TAG_REPO: ${{ github.repository }}
+        TAG_DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        set -euo pipefail
+        python3 "${{ github.action_path }}/tag_subdir.py"

--- a/.github/actions/tag-subdir/tag_subdir.py
+++ b/.github/actions/tag-subdir/tag_subdir.py
@@ -1,23 +1,11 @@
 #!/usr/bin/env python3
 
-# Tag missing versions of a subdir package at the commit recorded in each
-# version's General-registry PR.
+# Tag missing versions of a subdir Julia package at the commit recorded in
+# each version's General-registry PR. Replaces JuliaRegistries/TagBot's
+# subdir handling, which uses a tree-hash fast-path that picks a later
+# same-subtree commit instead of the registered one.
 #
-# Replaces JuliaRegistries/TagBot's subdir handling. Upstream TagBot resolves
-# version -> commit by walking `git log` in reverse-chronological order and
-# keeping the first commit whose subdir tree matches the registered tree.
-# When later commits on the trunk leave the subdir untouched, that fast path
-# picks a non-registered commit; the slow path that reads `Commit:` from the
-# registry PR body never runs because the fast path has already returned.
-#
-# This script always uses the commit recorded in the registry PR, with a
-# sanity check that the subdir tree at that commit matches the registered
-# `git-tree-sha1`.
-#
-# Idempotent: existing tags are never modified. Versions whose tag already
-# points at the registered commit are skipped silently. Versions whose tag
-# points at the wrong commit are skipped and reported (correction is a
-# separate, deliberate operation, not a side-effect of every TagBot run).
+# Idempotent: existing tags are never modified.
 #
 # Inputs (env):
 #   TAG_REPO          owner/name of the package repo (default: GITHUB_REPOSITORY)
@@ -26,8 +14,6 @@
 #   TAG_DRY_RUN       "true" to log without mutating
 #   GH_TOKEN          token for `gh api`
 
-from __future__ import annotations
-
 import base64
 import hashlib
 import json
@@ -35,171 +21,80 @@ import os
 import re
 import subprocess
 import sys
-from dataclasses import dataclass
+import tomllib
 
 GENERAL = "JuliaRegistries/General"
 
 
-@dataclass
-class GhResult:
-    code: int
-    stdout: str
-    stderr: str
-
-
-def gh(*args: str, check: bool = True) -> GhResult:
-    res = subprocess.run(
-        ["gh", "api", *args], capture_output=True, text=True
-    )
-    if check and res.returncode != 0:
-        sys.stderr.write(res.stdout)
-        sys.stderr.write(res.stderr)
-        raise SystemExit(f"gh api failed: {' '.join(args)}")
-    return GhResult(res.returncode, res.stdout, res.stderr)
-
-
-def gh_json(*args: str):
-    return json.loads(gh(*args).stdout)
-
-
-def get_or_none_404(*args: str):
-    res = gh(*args, check=False)
-    if res.code == 0:
-        return json.loads(res.stdout)
-    if "HTTP 404" in res.stderr or "Not Found" in res.stderr:
+def gh(*args, allow_404=False):
+    res = subprocess.run(["gh", "api", *args], capture_output=True, text=True)
+    if res.returncode == 0:
+        return json.loads(res.stdout) if res.stdout.strip() else None
+    if allow_404 and ("HTTP 404" in res.stderr or "Not Found" in res.stderr):
         return None
-    sys.stderr.write(res.stdout)
-    sys.stderr.write(res.stderr)
-    raise SystemExit(f"gh api failed: {' '.join(args)}")
+    sys.stderr.write(res.stdout + res.stderr)
+    sys.exit(f"gh api failed: {' '.join(args)}")
 
 
-# ---- General registry helpers ----
+def fetch_registry_toml(name, filename):
+    obj = gh(f"repos/{GENERAL}/contents/{name[0].upper()}/{name}/{filename}")
+    return tomllib.loads(base64.b64decode(obj["content"]).decode())
 
 
-def registry_dir(name: str) -> str:
-    if not name or not name[0].isalpha():
-        raise SystemExit(f"package name {name!r} has no alpha first character; can't locate in General")
-    return f"{name[0].upper()}/{name}"
-
-
-def registry_file(name: str, filename: str) -> str:
-    path = f"{registry_dir(name)}/{filename}"
-    obj = gh_json(f"repos/{GENERAL}/contents/{path}")
-    return base64.b64decode(obj["content"]).decode()
-
-
-# Versions.toml is `["VERSION"]` headers with a `git-tree-sha1 = "..."` line each.
-# Pure regex parser keeps this script free of TOML dependencies and is exact for
-# the documented format. Lines starting with `#` (comments) and other keys are
-# ignored; only the version header and tree-sha1 are read.
-_VERSION_HEADER = re.compile(r'^\["([^"]+)"\]\s*$', re.M)
-_TREE_SHA = re.compile(r'^\s*git-tree-sha1\s*=\s*"([0-9a-f]{40})"\s*$', re.M)
-
-
-def parse_versions(text: str) -> dict[str, str]:
-    out: dict[str, str] = {}
-    headers = list(_VERSION_HEADER.finditer(text))
-    for i, m in enumerate(headers):
-        version = m.group(1)
-        block_start = m.end()
-        block_end = headers[i + 1].start() if i + 1 < len(headers) else len(text)
-        sha = _TREE_SHA.search(text, block_start, block_end)
-        if not sha:
-            raise SystemExit(f"Versions.toml: no git-tree-sha1 for {version!r}")
-        out[version] = sha.group(1)
-    return out
-
-
-_REPO_RE = re.compile(r'^\s*repo\s*=\s*"([^"]+)"\s*$', re.M)
-_UUID_RE = re.compile(r'^\s*uuid\s*=\s*"([^"]+)"\s*$', re.M)
-_NAME_RE = re.compile(r'^\s*name\s*=\s*"([^"]+)"\s*$', re.M)
-
-
-def parse_package(text: str) -> dict:
-    def grab(rx: re.Pattern, label: str) -> str:
-        m = rx.search(text)
-        if not m:
-            raise SystemExit(f"Package.toml: missing {label}")
-        return m.group(1)
-    return {"name": grab(_NAME_RE, "name"), "uuid": grab(_UUID_RE, "uuid"), "repo": grab(_REPO_RE, "repo")}
-
-
-# ---- Registry PR ----
-
-
-def registrator_branch(name: str, uuid: str, version: str, repo_url: str) -> str:
-    # Mirrors RegistryTools.jl `registration_branch`:
-    # registrator-<lowercase_name>-<uuid[1:8]>-v<version>-<sha256(url)[1:10]>.
-    # Note the URL hash is sha256, not sha1.
-    h = hashlib.sha256(repo_url.encode()).hexdigest()[:10]
+def registrator_branch(name, uuid, version, url):
+    # Mirrors RegistryTools.jl `registration_branch`. URL hash is sha256, not sha1.
+    h = hashlib.sha256(url.encode()).hexdigest()[:10]
     return f"registrator-{name.lower()}-{uuid[:8]}-v{version}-{h}"
 
 
-def find_registry_pr(branch: str):
-    # Use the deterministic head-branch lookup. JuliaRegistrator pushes the
-    # branch into the JuliaRegistries/General repo itself (not a fork), so
-    # the head owner is `JuliaRegistries`.
-    prs = gh_json(
+_COMMIT_LINE = re.compile(r"^\s*[-*]\s*Commit:\s*([0-9a-f]{40})\s*$", re.M)
+
+
+def find_registered_commit(name, uuid, version, url):
+    branch = registrator_branch(name, uuid, version, url)
+    prs = gh(
         f"repos/{GENERAL}/pulls",
         "-X", "GET",
         "-f", "state=all",
         "-f", f"head=JuliaRegistries:{branch}",
         "-f", "per_page=1",
     )
-    return prs[0] if prs else None
-
-
-_COMMIT_LINE = re.compile(r"^\s*[-*]\s*Commit:\s*([0-9a-f]{40})\s*$", re.M)
-
-
-def parse_commit_from_body(body: str) -> str | None:
-    m = _COMMIT_LINE.search(body or "")
+    if not prs:
+        return None
+    m = _COMMIT_LINE.search(prs[0].get("body") or "")
     return m.group(1) if m else None
 
 
-# ---- Package repo helpers ----
-
-
-def root_tree_of_commit(repo: str, commit: str) -> str | None:
-    obj = get_or_none_404(f"repos/{repo}/commits/{commit}")
-    return obj["commit"]["tree"]["sha"] if obj else None
-
-
-def subdir_tree_at_commit(repo: str, commit: str, subdir: str) -> str | None:
-    root = root_tree_of_commit(repo, commit)
-    if root is None:
+def subdir_tree_sha(repo, commit, subdir):
+    # `git/trees/{sha}` accepts a commit SHA and returns its root tree directly.
+    tree = gh(f"repos/{repo}/git/trees/{commit}", allow_404=True)
+    if tree is None:
         return None
-    tree = gh_json(f"repos/{repo}/git/trees/{root}")
     for entry in tree["tree"]:
         if entry["path"] == subdir and entry["type"] == "tree":
             return entry["sha"]
     return None
 
 
-def deref_tag(repo: str, tag_name: str) -> str | None:
-    # Use the singular `git/ref/...` endpoint, which does an exact lookup. The
-    # plural `git/refs/...` does prefix matching and returns a list when
-    # multiple tags share a prefix (e.g. v0.1.3 matches v0.1.30, v0.1.31, ...).
-    ref = get_or_none_404(f"repos/{repo}/git/ref/tags/{tag_name}")
+def deref_tag(repo, tag):
+    # Singular `git/ref/...` does an exact lookup; the plural endpoint does
+    # prefix matching (e.g. `NDTensors-v0.1.3` matches `v0.1.30`, `v0.1.31`, ...).
+    ref = gh(f"repos/{repo}/git/ref/tags/{tag}", allow_404=True)
     if ref is None:
         return None
     obj = ref["object"]
     if obj["type"] == "commit":
         return obj["sha"]
     if obj["type"] == "tag":
-        annotated = gh_json(f"repos/{repo}/git/tags/{obj['sha']}")
-        return annotated["object"]["sha"]
-    raise SystemExit(f"unexpected tag object type: {obj['type']!r}")
+        return gh(f"repos/{repo}/git/tags/{obj['sha']}")["object"]["sha"]
+    sys.exit(f"unexpected tag object type: {obj['type']!r}")
 
 
-def create_tag_and_release(repo: str, tag_name: str, commit: str, message: str, dry_run: bool) -> None:
-    if dry_run:
-        print(f"  [dry-run] would create annotated tag {tag_name} -> {commit[:7]} and a release")
-        return
-    tag_obj = gh_json(
+def create_tag_and_release(repo, tag, commit, message):
+    obj = gh(
         f"repos/{repo}/git/tags",
         "-X", "POST",
-        "-f", f"tag={tag_name}",
+        "-f", f"tag={tag}",
         "-f", f"message={message}",
         "-f", f"object={commit}",
         "-f", "type=commit",
@@ -207,149 +102,86 @@ def create_tag_and_release(repo: str, tag_name: str, commit: str, message: str, 
     gh(
         f"repos/{repo}/git/refs",
         "-X", "POST",
-        "-f", f"ref=refs/tags/{tag_name}",
-        "-f", f"sha={tag_obj['sha']}",
+        "-f", f"ref=refs/tags/{tag}",
+        "-f", f"sha={obj['sha']}",
     )
     gh(
         f"repos/{repo}/releases",
         "-X", "POST",
-        "-f", f"tag_name={tag_name}",
-        "-f", f"name={tag_name}",
+        "-f", f"tag_name={tag}",
+        "-f", f"name={tag}",
         "-F", "generate_release_notes=true",
     )
-    print(f"  created tag {tag_name} -> {commit[:7]} and release")
 
 
-# ---- Main ----
+def version_key(version):
+    base = version.split("-", 1)[0]
+    return tuple(int(p) for p in base.split("."))
 
 
-def env(name: str, default: str | None = None) -> str:
-    val = os.environ.get(name, default)
-    if val is None or val == "":
-        raise SystemExit(f"required env var {name} is unset")
-    return val
-
-
-def main() -> int:
-    repo = env("TAG_REPO", os.environ.get("GITHUB_REPOSITORY"))
-    subdir = env("TAG_SUBDIR")
+def main():
+    repo = os.environ.get("TAG_REPO") or os.environ["GITHUB_REPOSITORY"]
+    subdir = os.environ["TAG_SUBDIR"]
     name = os.environ.get("TAG_PACKAGE_NAME") or subdir
     dry_run = os.environ.get("TAG_DRY_RUN", "false").lower() == "true"
 
     print(f"::group::tag-subdir: {name} (subdir={subdir}) in {repo}")
     print(f"  mode: {'dry-run' if dry_run else 'live'}")
 
-    pkg = parse_package(registry_file(name, "Package.toml"))
-    if pkg["name"] != name:
-        raise SystemExit(f"name mismatch: registry says {pkg['name']!r}, expected {name!r}")
-    pkg_repo_url = pkg["repo"]
-
-    # Sanity-check the package belongs to this repo. The General Package.toml
-    # `repo` is e.g. https://github.com/ITensor/ITensors.jl.git; we need to
-    # match against the runner's GITHUB_REPOSITORY (owner/name).
-    expected_path = f"/{repo}.git"
-    if not pkg_repo_url.endswith(expected_path) and not pkg_repo_url.endswith(f"/{repo}"):
-        raise SystemExit(
-            f"registered repo URL {pkg_repo_url!r} does not match TAG_REPO={repo!r}"
-        )
-
-    versions = parse_versions(registry_file(name, "Versions.toml"))
+    pkg = fetch_registry_toml(name, "Package.toml")
+    versions = fetch_registry_toml(name, "Versions.toml")
     print(f"  registered versions: {len(versions)}")
 
-    counts = {
-        "correct": 0,        # tag at registered commit
-        "old-correct": 0,    # tag exists, no PR found, subtree matches (pre-Registrator-era versions)
-        "wrong-commit": 0,   # tag at non-registered commit (Phase 2 backfill territory)
-        "wrong-subtree": 0,  # tag at commit whose subtree doesn't even match (very surprising)
-        "tagged": 0,         # newly tagged this run (or would-be in dry-run)
-        "no-pr-no-tag": 0,   # untagged and no PR: cannot auto-tag (e.g. ancient versions)
-        "tree-mismatch": 0,  # registry PR commit's subtree != registered tree (refuse)
-        "no-commit": 0,      # registry PR body has no `Commit:` line (refuse)
-    }
+    correct = old_correct = wrong = no_pr_no_tag = tagged = failed = 0
 
-    for version, registered_tree in sorted(
-        versions.items(), key=version_key
-    ):
+    for version in sorted(versions, key=version_key):
         tag_name = f"{name}-v{version}"
+        registered_tree = versions[version]["git-tree-sha1"]
         existing = deref_tag(repo, tag_name)
-        registered_commit = lookup_registered_commit(name, pkg["uuid"], version, pkg_repo_url)
+        registered = find_registered_commit(name, pkg["uuid"], version, pkg["repo"])
 
-        if existing is not None and registered_commit is not None:
-            if existing == registered_commit:
-                counts["correct"] += 1
+        if existing and registered:
+            if existing == registered:
+                correct += 1
             else:
-                counts["wrong-commit"] += 1
+                wrong += 1
                 print(
-                    f"  WRONG-COMMIT  {tag_name}: tag at {existing[:7]} != registered "
-                    f"{registered_commit[:7]}; not auto-correcting"
+                    f"  WRONG-COMMIT  {tag_name}: tag at {existing[:7]} != "
+                    f"registered {registered[:7]}; not auto-correcting"
                 )
-            continue
-
-        if existing is not None and registered_commit is None:
-            existing_subtree = subdir_tree_at_commit(repo, existing, subdir)
-            if existing_subtree == registered_tree:
-                counts["old-correct"] += 1
+        elif existing:
+            # Pre-Registrator versions: best we can do is verify subtree.
+            if subdir_tree_sha(repo, existing, subdir) == registered_tree:
+                old_correct += 1
             else:
-                counts["wrong-subtree"] += 1
+                failed += 1
                 print(
-                    f"  WRONG-SUBTREE {tag_name}: tag at {existing[:7]}, no registry PR "
-                    f"found, subdir tree {(existing_subtree or 'missing')[:7]} != "
-                    f"registered tree {registered_tree[:7]}"
+                    f"  WRONG-SUBTREE {tag_name}: tag at {existing[:7]}, no PR found, "
+                    f"subdir tree != registered tree {registered_tree[:7]}"
                 )
-            continue
+        elif registered:
+            actual = subdir_tree_sha(repo, registered, subdir)
+            if actual != registered_tree:
+                failed += 1
+                print(
+                    f"  TREE-MISMATCH {tag_name}: subdir tree at {registered[:7]} != "
+                    f"registered tree {registered_tree[:7]}; refusing to tag"
+                )
+                continue
+            print(f"  TAG           {tag_name} -> {registered[:7]}")
+            if not dry_run:
+                create_tag_and_release(repo, tag_name, registered, f"{name} v{version}")
+            tagged += 1
+        else:
+            no_pr_no_tag += 1
 
-        if existing is None and registered_commit is None:
-            counts["no-pr-no-tag"] += 1
-            continue
-
-        # existing is None and registered_commit is not None: tag.
-        actual_tree = subdir_tree_at_commit(repo, registered_commit, subdir)
-        if actual_tree != registered_tree:
-            counts["tree-mismatch"] += 1
-            print(
-                f"  TREE-MISMATCH {tag_name}: subdir tree at {registered_commit[:7]} is "
-                f"{(actual_tree or 'missing')[:7]}, but registered tree is "
-                f"{registered_tree[:7]}; refusing to tag"
-            )
-            continue
-
-        print(f"  TAG           {tag_name}: -> {registered_commit[:7]}")
-        create_tag_and_release(
-            repo,
-            tag_name,
-            registered_commit,
-            message=f"{name} v{version}",
-            dry_run=dry_run,
-        )
-        counts["tagged"] += 1
-
-    print("  ----")
-    print("  summary: " + " ".join(f"{k}={v}" for k, v in counts.items()))
+    print(
+        f"  summary: correct={correct} old-correct={old_correct} "
+        f"wrong-commit={wrong} no-pr-no-tag={no_pr_no_tag} "
+        f"tagged={tagged} failed={failed}"
+    )
     print("::endgroup::")
-
-    failed = counts["wrong-subtree"] + counts["tree-mismatch"] + counts["no-commit"]
     return 1 if failed else 0
-
-
-def version_key(kv):
-    """Sort key for SemVer-ish version strings used in Versions.toml.
-
-    Splits on `.` and pads to 3 numeric components; appends an empty
-    pre-release tuple so plain releases sort after their pre-releases under
-    standard tuple comparison."""
-    version = kv[0]
-    base = version.split("-", 1)[0]
-    parts = base.split(".")
-    nums = tuple(int(p) for p in parts) + (0,) * (3 - len(parts))
-    return nums + (version,)
-
-
-def lookup_registered_commit(name, uuid, version, repo_url):
-    branch = registrator_branch(name, uuid, version, repo_url)
-    pr = find_registry_pr(branch)
-    if pr is None:
-        return None
-    return parse_commit_from_body(pr.get("body") or "")
 
 
 if __name__ == "__main__":

--- a/.github/actions/tag-subdir/tag_subdir.py
+++ b/.github/actions/tag-subdir/tag_subdir.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+
+# Tag missing versions of a subdir package at the commit recorded in each
+# version's General-registry PR.
+#
+# Replaces JuliaRegistries/TagBot's subdir handling. Upstream TagBot resolves
+# version -> commit by walking `git log` in reverse-chronological order and
+# keeping the first commit whose subdir tree matches the registered tree.
+# When later commits on the trunk leave the subdir untouched, that fast path
+# picks a non-registered commit; the slow path that reads `Commit:` from the
+# registry PR body never runs because the fast path has already returned.
+#
+# This script always uses the commit recorded in the registry PR, with a
+# sanity check that the subdir tree at that commit matches the registered
+# `git-tree-sha1`.
+#
+# Idempotent: existing tags are never modified. Versions whose tag already
+# points at the registered commit are skipped silently. Versions whose tag
+# points at the wrong commit are skipped and reported (correction is a
+# separate, deliberate operation, not a side-effect of every TagBot run).
+#
+# Inputs (env):
+#   TAG_REPO          owner/name of the package repo (default: GITHUB_REPOSITORY)
+#   TAG_SUBDIR        subdir name within the repo (e.g. "NDTensors")
+#   TAG_PACKAGE_NAME  registered package name (default: TAG_SUBDIR)
+#   TAG_DRY_RUN       "true" to log without mutating
+#   GH_TOKEN          token for `gh api`
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+GENERAL = "JuliaRegistries/General"
+
+
+@dataclass
+class GhResult:
+    code: int
+    stdout: str
+    stderr: str
+
+
+def gh(*args: str, check: bool = True) -> GhResult:
+    res = subprocess.run(
+        ["gh", "api", *args], capture_output=True, text=True
+    )
+    if check and res.returncode != 0:
+        sys.stderr.write(res.stdout)
+        sys.stderr.write(res.stderr)
+        raise SystemExit(f"gh api failed: {' '.join(args)}")
+    return GhResult(res.returncode, res.stdout, res.stderr)
+
+
+def gh_json(*args: str):
+    return json.loads(gh(*args).stdout)
+
+
+def get_or_none_404(*args: str):
+    res = gh(*args, check=False)
+    if res.code == 0:
+        return json.loads(res.stdout)
+    if "HTTP 404" in res.stderr or "Not Found" in res.stderr:
+        return None
+    sys.stderr.write(res.stdout)
+    sys.stderr.write(res.stderr)
+    raise SystemExit(f"gh api failed: {' '.join(args)}")
+
+
+# ---- General registry helpers ----
+
+
+def registry_dir(name: str) -> str:
+    if not name or not name[0].isalpha():
+        raise SystemExit(f"package name {name!r} has no alpha first character; can't locate in General")
+    return f"{name[0].upper()}/{name}"
+
+
+def registry_file(name: str, filename: str) -> str:
+    path = f"{registry_dir(name)}/{filename}"
+    obj = gh_json(f"repos/{GENERAL}/contents/{path}")
+    return base64.b64decode(obj["content"]).decode()
+
+
+# Versions.toml is `["VERSION"]` headers with a `git-tree-sha1 = "..."` line each.
+# Pure regex parser keeps this script free of TOML dependencies and is exact for
+# the documented format. Lines starting with `#` (comments) and other keys are
+# ignored; only the version header and tree-sha1 are read.
+_VERSION_HEADER = re.compile(r'^\["([^"]+)"\]\s*$', re.M)
+_TREE_SHA = re.compile(r'^\s*git-tree-sha1\s*=\s*"([0-9a-f]{40})"\s*$', re.M)
+
+
+def parse_versions(text: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    headers = list(_VERSION_HEADER.finditer(text))
+    for i, m in enumerate(headers):
+        version = m.group(1)
+        block_start = m.end()
+        block_end = headers[i + 1].start() if i + 1 < len(headers) else len(text)
+        sha = _TREE_SHA.search(text, block_start, block_end)
+        if not sha:
+            raise SystemExit(f"Versions.toml: no git-tree-sha1 for {version!r}")
+        out[version] = sha.group(1)
+    return out
+
+
+_REPO_RE = re.compile(r'^\s*repo\s*=\s*"([^"]+)"\s*$', re.M)
+_UUID_RE = re.compile(r'^\s*uuid\s*=\s*"([^"]+)"\s*$', re.M)
+_NAME_RE = re.compile(r'^\s*name\s*=\s*"([^"]+)"\s*$', re.M)
+
+
+def parse_package(text: str) -> dict:
+    def grab(rx: re.Pattern, label: str) -> str:
+        m = rx.search(text)
+        if not m:
+            raise SystemExit(f"Package.toml: missing {label}")
+        return m.group(1)
+    return {"name": grab(_NAME_RE, "name"), "uuid": grab(_UUID_RE, "uuid"), "repo": grab(_REPO_RE, "repo")}
+
+
+# ---- Registry PR ----
+
+
+def registrator_branch(name: str, uuid: str, version: str, repo_url: str) -> str:
+    # Mirrors RegistryTools.jl `registration_branch`:
+    # registrator-<lowercase_name>-<uuid[1:8]>-v<version>-<sha256(url)[1:10]>.
+    # Note the URL hash is sha256, not sha1.
+    h = hashlib.sha256(repo_url.encode()).hexdigest()[:10]
+    return f"registrator-{name.lower()}-{uuid[:8]}-v{version}-{h}"
+
+
+def find_registry_pr(branch: str):
+    # Use the deterministic head-branch lookup. JuliaRegistrator pushes the
+    # branch into the JuliaRegistries/General repo itself (not a fork), so
+    # the head owner is `JuliaRegistries`.
+    prs = gh_json(
+        f"repos/{GENERAL}/pulls",
+        "-X", "GET",
+        "-f", "state=all",
+        "-f", f"head=JuliaRegistries:{branch}",
+        "-f", "per_page=1",
+    )
+    return prs[0] if prs else None
+
+
+_COMMIT_LINE = re.compile(r"^\s*[-*]\s*Commit:\s*([0-9a-f]{40})\s*$", re.M)
+
+
+def parse_commit_from_body(body: str) -> str | None:
+    m = _COMMIT_LINE.search(body or "")
+    return m.group(1) if m else None
+
+
+# ---- Package repo helpers ----
+
+
+def root_tree_of_commit(repo: str, commit: str) -> str | None:
+    obj = get_or_none_404(f"repos/{repo}/commits/{commit}")
+    return obj["commit"]["tree"]["sha"] if obj else None
+
+
+def subdir_tree_at_commit(repo: str, commit: str, subdir: str) -> str | None:
+    root = root_tree_of_commit(repo, commit)
+    if root is None:
+        return None
+    tree = gh_json(f"repos/{repo}/git/trees/{root}")
+    for entry in tree["tree"]:
+        if entry["path"] == subdir and entry["type"] == "tree":
+            return entry["sha"]
+    return None
+
+
+def deref_tag(repo: str, tag_name: str) -> str | None:
+    # Use the singular `git/ref/...` endpoint, which does an exact lookup. The
+    # plural `git/refs/...` does prefix matching and returns a list when
+    # multiple tags share a prefix (e.g. v0.1.3 matches v0.1.30, v0.1.31, ...).
+    ref = get_or_none_404(f"repos/{repo}/git/ref/tags/{tag_name}")
+    if ref is None:
+        return None
+    obj = ref["object"]
+    if obj["type"] == "commit":
+        return obj["sha"]
+    if obj["type"] == "tag":
+        annotated = gh_json(f"repos/{repo}/git/tags/{obj['sha']}")
+        return annotated["object"]["sha"]
+    raise SystemExit(f"unexpected tag object type: {obj['type']!r}")
+
+
+def create_tag_and_release(repo: str, tag_name: str, commit: str, message: str, dry_run: bool) -> None:
+    if dry_run:
+        print(f"  [dry-run] would create annotated tag {tag_name} -> {commit[:7]} and a release")
+        return
+    tag_obj = gh_json(
+        f"repos/{repo}/git/tags",
+        "-X", "POST",
+        "-f", f"tag={tag_name}",
+        "-f", f"message={message}",
+        "-f", f"object={commit}",
+        "-f", "type=commit",
+    )
+    gh(
+        f"repos/{repo}/git/refs",
+        "-X", "POST",
+        "-f", f"ref=refs/tags/{tag_name}",
+        "-f", f"sha={tag_obj['sha']}",
+    )
+    gh(
+        f"repos/{repo}/releases",
+        "-X", "POST",
+        "-f", f"tag_name={tag_name}",
+        "-f", f"name={tag_name}",
+        "-F", "generate_release_notes=true",
+    )
+    print(f"  created tag {tag_name} -> {commit[:7]} and release")
+
+
+# ---- Main ----
+
+
+def env(name: str, default: str | None = None) -> str:
+    val = os.environ.get(name, default)
+    if val is None or val == "":
+        raise SystemExit(f"required env var {name} is unset")
+    return val
+
+
+def main() -> int:
+    repo = env("TAG_REPO", os.environ.get("GITHUB_REPOSITORY"))
+    subdir = env("TAG_SUBDIR")
+    name = os.environ.get("TAG_PACKAGE_NAME") or subdir
+    dry_run = os.environ.get("TAG_DRY_RUN", "false").lower() == "true"
+
+    print(f"::group::tag-subdir: {name} (subdir={subdir}) in {repo}")
+    print(f"  mode: {'dry-run' if dry_run else 'live'}")
+
+    pkg = parse_package(registry_file(name, "Package.toml"))
+    if pkg["name"] != name:
+        raise SystemExit(f"name mismatch: registry says {pkg['name']!r}, expected {name!r}")
+    pkg_repo_url = pkg["repo"]
+
+    # Sanity-check the package belongs to this repo. The General Package.toml
+    # `repo` is e.g. https://github.com/ITensor/ITensors.jl.git; we need to
+    # match against the runner's GITHUB_REPOSITORY (owner/name).
+    expected_path = f"/{repo}.git"
+    if not pkg_repo_url.endswith(expected_path) and not pkg_repo_url.endswith(f"/{repo}"):
+        raise SystemExit(
+            f"registered repo URL {pkg_repo_url!r} does not match TAG_REPO={repo!r}"
+        )
+
+    versions = parse_versions(registry_file(name, "Versions.toml"))
+    print(f"  registered versions: {len(versions)}")
+
+    counts = {
+        "correct": 0,        # tag at registered commit
+        "old-correct": 0,    # tag exists, no PR found, subtree matches (pre-Registrator-era versions)
+        "wrong-commit": 0,   # tag at non-registered commit (Phase 2 backfill territory)
+        "wrong-subtree": 0,  # tag at commit whose subtree doesn't even match (very surprising)
+        "tagged": 0,         # newly tagged this run (or would-be in dry-run)
+        "no-pr-no-tag": 0,   # untagged and no PR: cannot auto-tag (e.g. ancient versions)
+        "tree-mismatch": 0,  # registry PR commit's subtree != registered tree (refuse)
+        "no-commit": 0,      # registry PR body has no `Commit:` line (refuse)
+    }
+
+    for version, registered_tree in sorted(
+        versions.items(), key=version_key
+    ):
+        tag_name = f"{name}-v{version}"
+        existing = deref_tag(repo, tag_name)
+        registered_commit = lookup_registered_commit(name, pkg["uuid"], version, pkg_repo_url)
+
+        if existing is not None and registered_commit is not None:
+            if existing == registered_commit:
+                counts["correct"] += 1
+            else:
+                counts["wrong-commit"] += 1
+                print(
+                    f"  WRONG-COMMIT  {tag_name}: tag at {existing[:7]} != registered "
+                    f"{registered_commit[:7]}; not auto-correcting"
+                )
+            continue
+
+        if existing is not None and registered_commit is None:
+            existing_subtree = subdir_tree_at_commit(repo, existing, subdir)
+            if existing_subtree == registered_tree:
+                counts["old-correct"] += 1
+            else:
+                counts["wrong-subtree"] += 1
+                print(
+                    f"  WRONG-SUBTREE {tag_name}: tag at {existing[:7]}, no registry PR "
+                    f"found, subdir tree {(existing_subtree or 'missing')[:7]} != "
+                    f"registered tree {registered_tree[:7]}"
+                )
+            continue
+
+        if existing is None and registered_commit is None:
+            counts["no-pr-no-tag"] += 1
+            continue
+
+        # existing is None and registered_commit is not None: tag.
+        actual_tree = subdir_tree_at_commit(repo, registered_commit, subdir)
+        if actual_tree != registered_tree:
+            counts["tree-mismatch"] += 1
+            print(
+                f"  TREE-MISMATCH {tag_name}: subdir tree at {registered_commit[:7]} is "
+                f"{(actual_tree or 'missing')[:7]}, but registered tree is "
+                f"{registered_tree[:7]}; refusing to tag"
+            )
+            continue
+
+        print(f"  TAG           {tag_name}: -> {registered_commit[:7]}")
+        create_tag_and_release(
+            repo,
+            tag_name,
+            registered_commit,
+            message=f"{name} v{version}",
+            dry_run=dry_run,
+        )
+        counts["tagged"] += 1
+
+    print("  ----")
+    print("  summary: " + " ".join(f"{k}={v}" for k, v in counts.items()))
+    print("::endgroup::")
+
+    failed = counts["wrong-subtree"] + counts["tree-mismatch"] + counts["no-commit"]
+    return 1 if failed else 0
+
+
+def version_key(kv):
+    """Sort key for SemVer-ish version strings used in Versions.toml.
+
+    Splits on `.` and pads to 3 numeric components; appends an empty
+    pre-release tuple so plain releases sort after their pre-releases under
+    standard tuple comparison."""
+    version = kv[0]
+    base = version.split("-", 1)[0]
+    parts = base.split(".")
+    nums = tuple(int(p) for p in parts) + (0,) * (3 - len(parts))
+    return nums + (version,)
+
+
+def lookup_registered_commit(name, uuid, version, repo_url):
+    branch = registrator_branch(name, uuid, version, repo_url)
+    pr = find_registry_pr(branch)
+    if pr is None:
+        return None
+    return parse_commit_from_body(pr.get("body") or "")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -29,12 +29,14 @@ jobs:
   TagBotGeneralSubdirs:
     if: "${{ inputs.subdirs != '[]' }}"
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: "write"
     strategy:
       fail-fast: false
       matrix:
         subdir: "${{ fromJSON(inputs.subdirs) }}"
     steps:
-      - uses: "JuliaRegistries/TagBot@v1"
+      - uses: "ITensor/ITensorActions/.github/actions/tag-subdir@main"
         with:
-          token: "${{ secrets.TAGBOT_PAT || github.token }}"
           subdir: "${{ matrix.subdir }}"
+          token: "${{ secrets.TAGBOT_PAT || github.token }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*.swp
 .worktrees/
+__pycache__/


### PR DESCRIPTION
## Summary

Replace the `TagBotGeneralSubdirs` job's `JuliaRegistries/TagBot@v1` step with a custom composite action that always tags the commit recorded in each version's General-registry PR.

Upstream TagBot resolves a registered version to a commit by walking `git log` in reverse-chronological order and keeping the first commit whose subdir tree matches the registered `git-tree-sha1`. For non-subdir packages this practically uniquely identifies the registered commit. For subdir packages, later commits that don't touch the subdir share the same subdir tree, so the fast path picks the most recent same-subtree commit instead of the registered one. The slow path that reads `Commit:` from the registry PR body never runs because the fast path returns first.

The new composite action (`.github/actions/tag-subdir`) skips the fast path entirely. For each registered version it:

1. Reads the General-registry path's `Versions.toml` for the canonical version list and per-version `git-tree-sha1`.
2. Looks up the registry PR via Registrator's deterministic head-branch format `registrator-<lowercase_name>-<uuid8>-v<version>-<sha256(url)[:10]>`.
3. Parses the `- Commit:` line from the PR body, sanity-checks that the subdir tree at that commit matches the registered `git-tree-sha1`, and creates an annotated tag plus a release with auto-generated notes.

Idempotent: existing tags are never modified. Versions whose tag points at the registered commit are skipped silently. Versions whose tag points at a different commit are skipped and reported — correction is a deliberate operation, not a side-effect of every TagBot run. Untagged versions whose registry PR can't be located by deterministic branch name (pre-Registrator-era registrations) are also skipped silently.

`TagBotGeneral` (non-subdir, General registry) and `TagBotITensorRegistry` are unchanged — upstream's tree-hash lookup is correct for non-subdir packages, and `ITensorRegistry` has no subdir packages.

## Dry-run output (186 NDTensors versions on ITensor/ITensors.jl)

```
summary: correct=75 old-correct=13 wrong-commit=65 no-pr-no-tag=33 tagged=0 failed=0
```

- **correct=75** — tag points at the registered commit.
- **old-correct=13** — tag exists, no Registrator-deterministic-branch PR found, subdir tree matches (v0.1.33–v0.1.45, predates Registrator's deterministic branch naming).
- **wrong-commit=65** — tag at a non-registered same-subtree commit (the known historical mismatch set; reported but not auto-corrected).
- **no-pr-no-tag=33** — untagged + no PR (v0.1.0–v0.1.32, ancient).

Spot-check on the case that motivated this work — NDTensors v0.4.27:

```
WRONG-COMMIT  NDTensors-v0.4.27: tag at 4f0e3cd != registered 0cfaf4f; not auto-correcting
```

The script picks `0cfaf4f` (the commit recorded in the registry PR), not `4f0e3cd` (the most recent same-subtree commit, which is what upstream TagBot picked).

## Notes

- The composite action is referenced by absolute path (`ITensor/ITensorActions/.github/actions/tag-subdir@main`) so the reusable workflow loads it from this repo regardless of the caller. Same idiom already used by `VersionCheck.yml` for `classify-pr`.
- The `permissions: contents: write` block on `TagBotGeneralSubdirs` is needed because the new action creates tags and releases via the GitHub API (the previous `JuliaRegistries/TagBot@v1` got these permissions implicitly through `secrets.TAGBOT_PAT`).
- If `JuliaRegistries/TagBot` ever flips its commit-resolution order (or always uses `_commit_sha_from_registry_pr` when `subdir` is set), this composite action becomes redundant and the `TagBotGeneralSubdirs` step can be reverted to a plain `uses: JuliaRegistries/TagBot@v1` with `subdir: ${{ matrix.subdir }}`.