### PR TITLE
Harden reusable workflows and introduce v1 versioning

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -55,6 +55,8 @@ jobs:
     if: "${{ !github.event.pull_request.draft || inputs.run-on-draft }}"
     runs-on: "ubuntu-latest"
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -18,6 +18,9 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check if Julia is already available in the PATH
         id: julia_in_path
@@ -62,6 +65,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.COMPATHELPER_PAT || secrets.GITHUB_TOKEN }}
       - name: "Run CompatHelper"
+        shell: julia --color=yes {0}
+        env:
+          # Use COMPATHELPER_PAT if available so that pushes trigger CI workflows.
+          # The built-in GITHUB_TOKEN can't trigger other workflows
+          # (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
+          GITHUB_TOKEN: ${{ secrets.COMPATHELPER_PAT || secrets.GITHUB_TOKEN }}
+          LOCALREGISTRY: ${{ inputs.localregistry }}
+          TOKEN_OWNER: ${{ steps.token-owner.outputs.login }}
         run: |
           import CompatHelper
           import LibGit2
@@ -83,8 +94,9 @@ jobs:
               name = "General",
             )
           ]
-          if !isempty("${{ inputs.localregistry }}")
-            registry_urls = split("${{ inputs.localregistry }}", "\n") .|> string
+          localregistry = get(ENV, "LOCALREGISTRY", "")
+          if !isempty(localregistry)
+            registry_urls = split(localregistry, "\n") .|> string
             for registry_url in registry_urls
               isempty(registry_url) && continue
               registry_name = registry_name_from_url(registry_url)
@@ -94,14 +106,8 @@ jobs:
             end
           end
           subdirs = ["", "docs", "examples", "test"]
-          token_owner = "${{ steps.token-owner.outputs.login }}"
+          token_owner = get(ENV, "TOKEN_OWNER", "")
           ci_cfg = isempty(token_owner) ?
               CompatHelper.GitHubActions() :
               CompatHelper.GitHubActions(; username=token_owner)
           CompatHelper.main(ENV, ci_cfg; registries, subdirs, bump_version=true)
-        shell: julia --color=yes {0}
-        env:
-          # Use COMPATHELPER_PAT if available so that pushes trigger CI workflows.
-          # The built-in GITHUB_TOKEN can't trigger other workflows
-          # (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
-          GITHUB_TOKEN: ${{ secrets.COMPATHELPER_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -75,14 +75,19 @@ jobs:
     name: "Build and Deploy Documentation"
     continue-on-error: ${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
       - name: "Install apt packages"
         if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"
+        env:
+          APT_PACKAGES: ${{ inputs.apt-packages }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y ${{ inputs.apt-packages }}
+          # shellcheck disable=SC2086
+          sudo apt-get install -y $APT_PACKAGES
 
       - name: "Setup Julia ${{ inputs.julia-version }}"
         uses: julia-actions/setup-julia@v2
@@ -97,21 +102,27 @@ jobs:
       - name: "Export extra environment variables"
         if: "${{ inputs.extra-env != '' }}"
         shell: "bash"
+        env:
+          EXTRA_ENV: ${{ inputs.extra-env }}
         run: |
-          echo "${{ inputs.extra-env }}" >> "$GITHUB_ENV"
+          printf '%s\n' "$EXTRA_ENV" >> "$GITHUB_ENV"
 
       - name: Setup project
         shell: "bash"
+        env:
+          DOC_PREFIX: ${{ inputs.doc-prefix }}
+          LOCALREGISTRY: ${{ inputs.localregistry }}
         run: |
-          ${{ inputs.doc-prefix }}julia --project=docs --color=yes <<'EOF'
+          ${DOC_PREFIX}julia --project=docs --color=yes <<'EOF'
           import Pkg
           if VERSION >= v"1.8-"
             Pkg.Registry.add()
           else
             Pkg.Registry.add("General")
           end
-          if !isempty("${{ inputs.localregistry }}")
-            local_repos = split("${{ inputs.localregistry }}", "\n") .|> string
+          localregistry = get(ENV, "LOCALREGISTRY", "")
+          if !isempty(localregistry)
+            local_repos = split(localregistry, "\n") .|> string
             for repo_url in local_repos
               isempty(repo_url) && continue
               Pkg.Registry.add(Pkg.RegistrySpec(; url=repo_url))
@@ -123,7 +134,10 @@ jobs:
       - name: "Build and Deploy Documentation"
         env:
           GITHUB_TOKEN: ${{ inputs.github-token || secrets.GITHUB_TOKEN }}
-        run: ${{ inputs.debug-documenter && 'JULIA_DEBUG="Documenter"' || '' }} ${{ inputs.doc-prefix }}julia --project=docs/ ${{ inputs.coverage && '--code-coverage=user' }} docs/make.jl
+          DOC_PREFIX: ${{ inputs.doc-prefix }}
+          JULIA_DEBUG: ${{ inputs.debug-documenter && 'Documenter' || '' }}
+          COVERAGE_FLAG: ${{ inputs.coverage && '--code-coverage=user' || '' }}
+        run: ${DOC_PREFIX}julia --project=docs/ $COVERAGE_FLAG docs/make.jl
 
       - uses: julia-actions/julia-processcoverage@v1
         if: "${{ inputs.coverage }}"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -6,9 +6,9 @@ name: "Reusable Format Checking Workflow"
 # secrets. The check status this workflow emits is what branch
 # protection should require.
 #
-# Companion: FormatCheckPostback.yml runs on `workflow_run:` after this
+# Companion: FormatCheckComment.yml runs on `workflow_run:` after this
 # workflow finishes, downloads the artifact uploaded here, and posts /
-# updates the format-suggestion comment. The postback runs in the base
+# updates the format-suggestion comment. The comment workflow runs in the base
 # repo's trusted context so it can use `FORMATPULLREQUEST_PAT` without
 # exposing it to the parse phase.
 
@@ -53,6 +53,7 @@ jobs:
       - name: Check out PR head
         uses: actions/checkout@v5
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
@@ -98,7 +99,7 @@ jobs:
             echo "exit_code=0" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Save metadata for postback
+      - name: Save metadata for comment workflow
         if: ${{ always() }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -111,7 +112,7 @@ jobs:
             echo "exit_code=${EXIT_CODE:-2}"
           } > metadata.txt
 
-      - name: Upload artifact for postback
+      - name: Upload artifact for comment workflow
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,5 +1,17 @@
 name: "Reusable Format Checking Workflow"
 
+# Parse phase of the format-check pipeline. Designed to run on
+# `pull_request:` (no secrets, read-only `GITHUB_TOKEN` for fork PRs)
+# so that PR-controlled content the formatter touches can never reach
+# secrets. The check status this workflow emits is what branch
+# protection should require.
+#
+# Companion: FormatCheckPostback.yml runs on `workflow_run:` after this
+# workflow finishes, downloads the artifact uploaded here, and posts /
+# updates the format-suggestion comment. The postback runs in the base
+# repo's trusted context so it can use `FORMATPULLREQUEST_PAT` without
+# exposing it to the parse phase.
+
 on:
   workflow_call:
     inputs:
@@ -25,11 +37,8 @@ on:
         type: boolean
 
 concurrency:
-  # Key on the PR number for `pull_request_target` events; `github.ref` would
-  # resolve to the target branch (`refs/heads/main`) and would put every PR's
-  # format check into the same group, causing each new PR to cancel all other
-  # in-progress format checks across the repo. Fall back to `github.ref` for
-  # non-PR triggers.
+  # Key on the PR number so each PR has its own concurrency group;
+  # falling back to `github.ref` for non-PR triggers.
   group: "${{ inputs.concurrent-jobs && github.run_id || github.event.pull_request.number || github.ref }}:${{ github.workflow }}"
   cancel-in-progress: ${{ !inputs.concurrent-jobs && inputs.cancel-in-progress }}
 
@@ -37,25 +46,21 @@ jobs:
   format-check:
     name: "Check Formatting"
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
-      actions: write
-      pull-requests: write
 
     steps:
-      - name: Check out repository
+      - name: Check out PR head
         uses: actions/checkout@v5
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Julia
         uses: julia-actions/setup-julia@v2
         with:
-          version: '${{ inputs.julia-version }}'
-          arch: 'x64'
+          version: "${{ inputs.julia-version }}"
+          arch: "x64"
 
       - uses: julia-actions/cache@v2
 
@@ -71,76 +76,54 @@ jobs:
 
       - name: Run ITensorFormatter
         id: format
+        env:
+          DIRECTORY: ${{ inputs.directory }}
         run: |
           set +e
-          echo "Formatter will run on: ${{ inputs.directory }}"
-          itpkgfmt ${{ inputs.directory }}
+          echo "Formatter will run on: $DIRECTORY"
+          itpkgfmt "$DIRECTORY"
           FORMAT_EXIT=$?
           if [ $FORMAT_EXIT -ne 0 ]; then
-            echo "exit_code=2" >> $GITHUB_OUTPUT
-            echo "diff=" >> $GITHUB_OUTPUT
-            exit 1
+            : > diff.patch
+            echo "exit_code=2" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-
-          # Report all changes introduced by the formatter (including newly created files).
-          # `git add -N .` makes newly created (untracked) files appear in `git diff` as additions.
+          # `git add -N .` makes new (untracked) files visible to `git diff`
+          # so the diff captured below covers added files as well.
           git add -N .
-          DIFF=$(git diff)
-          if [ -n "$DIFF" ]; then
-            EXIT_CODE=1
+          git diff > diff.patch
+          if [ -s diff.patch ]; then
+            echo "exit_code=1" >> "$GITHUB_OUTPUT"
           else
-            EXIT_CODE=0
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
-          echo "diff<<EOF" >> $GITHUB_OUTPUT
-          echo "$DIFF" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Save metadata for postback
+        if: ${{ always() }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EXIT_CODE: ${{ steps.format.outputs.exit_code }}
+        run: |
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "pr_head_sha=$PR_HEAD_SHA"
+            echo "exit_code=${EXIT_CODE:-2}"
+          } > metadata.txt
 
-      - name: Find comment
-        uses: peter-evans/find-comment@v3
-        id: find-comment
+      - name: Upload artifact for postback
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.FORMATPULLREQUEST_PAT || github.token }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: '<!-- format-check-summary -->'
-
-      - name: Comment formatting suggestions
-        if: steps.format.outputs.exit_code == 1
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          token: ${{ secrets.FORMATPULLREQUEST_PAT || github.token }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            <!-- format-check-summary -->
-
-            Your PR requires formatting changes to meet the project's style guidelines.
-            Please run the [ITensorFormatter](https://github.com/ITensor/ITensorFormatter.jl) to apply these changes.
-
-            <details>
-            <summary>Click here to view the suggested changes.</summary>
-
-            ~~~diff
-            ${{ steps.format.outputs.diff }}
-            ~~~
-
-            </details>
-          edit-mode: replace
-
-      - name: Update stale comment
-        if: steps.format.outputs.exit_code == 0 && steps.find-comment.outputs.comment-id
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          token: ${{ secrets.FORMATPULLREQUEST_PAT || github.token }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            <!-- format-check-summary -->
-
-            Your PR no longer requires formatting changes. Thank you for your contribution!
-          edit-mode: replace
+          name: format-check
+          path: |
+            metadata.txt
+            diff.patch
+          if-no-files-found: ignore
 
       - name: Propagate exit code
         run: |
+          # exit 0 -> already formatted; exit 1 -> formatting needed;
+          # exit 2 -> formatter itself errored. The check status reflects
+          # this directly so branch protection can require it.
           exit ${{ steps.format.outputs.exit_code }}

--- a/.github/workflows/FormatCheckComment.yml
+++ b/.github/workflows/FormatCheckComment.yml
@@ -1,11 +1,10 @@
-name: "Reusable Format Check Postback Workflow"
+name: "Reusable Format Check Comment Workflow"
 
-# Postback phase of the format-check pipeline. Triggered by a
-# `workflow_run` event after FormatCheck.yml completes. Runs in the
-# base repo's trusted context (with secrets, write-scope
-# `GITHUB_TOKEN`) and never touches PR-controlled code: it only
-# downloads the diff artifact produced by the parse phase and posts
-# or updates the format-suggestion comment on the PR.
+# Comment phase of the format-check pipeline. Triggered by a `workflow_run`
+# event after FormatCheck.yml completes. Runs in the base repo's trusted
+# context (with secrets, write-scope `GITHUB_TOKEN`) and never touches
+# PR-controlled code: it only downloads the diff artifact produced by the parse
+# phase and posts or updates the format-suggestion comment on the PR.
 #
 # Branch protection should require the FormatCheck check, not this
 # one — this workflow's job exists to update the comment, not to gate
@@ -15,13 +14,13 @@ on:
   workflow_call:
     inputs:
       check-name:
-        description: "Name of the parse-phase workflow this postback runs against. Used to filter unrelated workflow_run events."
+        description: "Name of the parse-phase workflow this comment workflow runs after. Used to filter unrelated workflow_run events."
         default: "Format Check"
         required: false
         type: string
 
 jobs:
-  postback:
+  comment:
     name: "Post format-check comment"
     # Only run when the parse-phase workflow that triggered us is the
     # expected FormatCheck workflow on a pull_request event.
@@ -47,14 +46,14 @@ jobs:
         id: meta
         run: |
           if [ ! -f metadata.txt ]; then
-            echo "metadata.txt missing; skipping postback."
+            echo "metadata.txt missing; skipping comment update."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           PR_NUMBER=$(grep -E '^pr_number=' metadata.txt | cut -d= -f2-)
           EXIT_CODE=$(grep -E '^exit_code=' metadata.txt | cut -d= -f2-)
           if [ -z "$PR_NUMBER" ]; then
-            echo "pr_number empty; skipping postback."
+            echo "pr_number empty; skipping comment update."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/FormatCheckPostback.yml
+++ b/.github/workflows/FormatCheckPostback.yml
@@ -1,0 +1,115 @@
+name: "Reusable Format Check Postback Workflow"
+
+# Postback phase of the format-check pipeline. Triggered by a
+# `workflow_run` event after FormatCheck.yml completes. Runs in the
+# base repo's trusted context (with secrets, write-scope
+# `GITHUB_TOKEN`) and never touches PR-controlled code: it only
+# downloads the diff artifact produced by the parse phase and posts
+# or updates the format-suggestion comment on the PR.
+#
+# Branch protection should require the FormatCheck check, not this
+# one — this workflow's job exists to update the comment, not to gate
+# merging.
+
+on:
+  workflow_call:
+    inputs:
+      check-name:
+        description: "Name of the parse-phase workflow this postback runs against. Used to filter unrelated workflow_run events."
+        default: "Format Check"
+        required: false
+        type: string
+
+jobs:
+  postback:
+    name: "Post format-check comment"
+    # Only run when the parse-phase workflow that triggered us is the
+    # expected FormatCheck workflow on a pull_request event.
+    if: >-
+      github.event.workflow_run.name == inputs.check-name
+      && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download FormatCheck artifact
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          name: format-check
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+        continue-on-error: true
+
+      - name: Read metadata
+        if: steps.download.outcome == 'success'
+        id: meta
+        run: |
+          if [ ! -f metadata.txt ]; then
+            echo "metadata.txt missing; skipping postback."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR_NUMBER=$(grep -E '^pr_number=' metadata.txt | cut -d= -f2-)
+          EXIT_CODE=$(grep -E '^exit_code=' metadata.txt | cut -d= -f2-)
+          if [ -z "$PR_NUMBER" ]; then
+            echo "pr_number empty; skipping postback."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing format-check comment
+        if: steps.meta.outputs.skip == 'false'
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          token: ${{ secrets.FORMATPULLREQUEST_PAT || github.token }}
+          issue-number: ${{ steps.meta.outputs.pr_number }}
+          body-includes: "<!-- format-check-summary -->"
+
+      - name: Compose suggestion-comment body
+        if: steps.meta.outputs.skip == 'false' && steps.meta.outputs.exit_code == '1'
+        run: |
+          {
+            echo "<!-- format-check-summary -->"
+            echo
+            echo "Your PR requires formatting changes to meet the project's style guidelines."
+            echo "Please run the [ITensorFormatter](https://github.com/ITensor/ITensorFormatter.jl) to apply these changes."
+            echo
+            echo "<details>"
+            echo "<summary>Click here to view the suggested changes.</summary>"
+            echo
+            echo '~~~diff'
+            cat diff.patch
+            echo
+            echo '~~~'
+            echo
+            echo "</details>"
+          } > comment-body.md
+
+      - name: Post or update suggestion comment
+        if: steps.meta.outputs.skip == 'false' && steps.meta.outputs.exit_code == '1'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.FORMATPULLREQUEST_PAT || github.token }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.meta.outputs.pr_number }}
+          body-path: comment-body.md
+          edit-mode: replace
+
+      - name: Clear stale comment when formatting now passes
+        if: steps.meta.outputs.skip == 'false' && steps.meta.outputs.exit_code == '0' && steps.find-comment.outputs.comment-id
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.FORMATPULLREQUEST_PAT || github.token }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.meta.outputs.pr_number }}
+          body: |
+            <!-- format-check-summary -->
+
+            Your PR no longer requires formatting changes. Thank you for your contribution!
+          edit-mode: replace

--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -29,6 +29,9 @@ jobs:
         contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) &&
         contains(github.event.comment.body, inputs.trigger)
       )
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Get PR branch
         if: github.event_name == 'issue_comment'
@@ -63,8 +66,10 @@ jobs:
           echo "$HOME/.julia/bin" >> $GITHUB_PATH
 
       - name: Run ITensorFormatter
+        env:
+          DIRECTORY: ${{ inputs.directory }}
         run: |
-          itpkgfmt ${{ inputs.directory }}
+          itpkgfmt "$DIRECTORY"
         continue-on-error: true
 
       - name: Detect formatting changes

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -8,8 +8,8 @@ on:
         default: "1"
         required: false
         type: string
-      pkg:
-        description: "Package name without `.jl` (e.g. ITensors for ITensors.jl), or a URL (https/git@) for private or unregistered packages."
+      pkgs:
+        description: "JSON-array string of package names (e.g. `'[\"BlockSparseArrays\", \"GradedArrays\"]'`) and/or git URLs (https/git@) for unregistered or private packages. Use `'[]'` when no downstream integration tests should run."
         required: true
         type: string
       localregistry:
@@ -34,58 +34,99 @@ on:
 
 jobs:
   test:
-    name: ${{ inputs.pkg }}
+    name: ${{ matrix.pkg }}
     if: "!github.event.pull_request.draft || inputs.run-on-draft"
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        pkg: ${{ fromJSON(inputs.pkgs) }}
 
     steps:
-      - name: "No downstream packages configured"
-        if: inputs.pkg == '__none__'
-        run: echo "No downstream integration tests configured."
+      # Decide whether this matrix leg should run, and emit `skip=true|false`.
+      # Skips when the entry is a URL that needs auth and the PR is from a
+      # fork (no secrets are exposed to fork PRs under `pull_request:`).
+      # Runs in every other case, including registered package names,
+      # URL entries reachable anonymously, and URL entries on internal PRs /
+      # push events / `pull_request_target` / `issue_comment` /
+      # `workflow_dispatch` (where secrets are in scope).
+      - name: "Decide whether to run"
+        id: gate
+        env:
+          PKG: ${{ matrix.pkg }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "$PKG" != https://* && "$PKG" != git@* ]]; then
+            echo "Registered package '$PKG'; running test."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # URL-based dep: probe anonymously to detect whether auth is needed.
+          # `credential.helper=` disables any helper that might silently
+          # supply credentials; `timeout` bounds a slow network probe.
+          if timeout 30 git -c credential.helper= ls-remote --exit-code "$PKG" HEAD &>/dev/null; then
+            echo "URL '$PKG' is reachable anonymously; running test."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Anonymous probe failed: the URL needs auth (or is unreachable).
+          # Skip only in the one context where the workflow has no secrets:
+          # a `pull_request` event from a fork.
+          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::notice::URL dependency '$PKG' requires authentication and this PR is from a fork. Skipping. Run \`/integrationtest $PKG\` on the PR to test it manually."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "URL '$PKG' needs auth; running with secrets in scope (event '$EVENT_NAME')."
+          echo "skip=false" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
-        if: inputs.pkg != '__none__'
+        if: steps.gate.outputs.skip != 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: julia-actions/setup-julia@v2
-        if: inputs.pkg != '__none__'
+        if: steps.gate.outputs.skip != 'true'
         with:
           version: ${{ inputs.julia-version }}
           arch: x64
       - name: "Configure git authentication for private repository"
-        if: inputs.pkg != '__none__'
+        if: steps.gate.outputs.skip != 'true'
         env:
           TOKEN: ${{ secrets.INTEGRATIONTEST_PAT }}
+          PKG: ${{ matrix.pkg }}
         run: |
-          pkg="${{ inputs.pkg }}"
-          if [[ "$pkg" == https://* ]] || [[ "$pkg" == git@* ]]; then
+          if [[ "$PKG" == https://* ]] || [[ "$PKG" == git@* ]]; then
             if [ -n "$TOKEN" ]; then
               git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
             fi
           fi
       - name: Run the downstream tests
-        if: inputs.pkg != '__none__'
+        if: steps.gate.outputs.skip != 'true'
         shell: julia --color=yes --project=downstream {0}
         env:
+          PKG: ${{ matrix.pkg }}
+          LOCALREGISTRY: ${{ inputs.localregistry }}
+          EXTRA_DEV_PATHS: ${{ inputs.extra-dev-paths }}
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
         run: |
           using Pkg
           Pkg.Registry.add("General")
           # If provided add local registries
-          if !isempty("${{ inputs.localregistry }}")
-            registry_urls = split("${{ inputs.localregistry }}", "\n") .|> string
+          localregistry = get(ENV, "LOCALREGISTRY", "")
+          if !isempty(localregistry)
+            registry_urls = split(localregistry, "\n") .|> string
             for registry_url in registry_urls
               isempty(registry_url) && continue
               Pkg.Registry.add(Pkg.RegistrySpec(; url=registry_url))
             end
           end
-          dev_paths = [".", split("${{ inputs['extra-dev-paths'] }}", "\n")...]
+          dev_paths = [".", split(get(ENV, "EXTRA_DEV_PATHS", ""), "\n")...]
           filter!(!isempty, dev_paths)
           dev_specs = [PackageSpec(; path) for path in dev_paths]
-          pkg = "${{ inputs.pkg }}"
+          pkg = get(ENV, "PKG", "")
           try
             if startswith(pkg, "https://") || startswith(pkg, "git@")
               # URL: unregistered or private package, skip version-pinning.
@@ -116,3 +157,46 @@ jobs:
             @info "Not compatible with this release. No problem." exception=err
             exit(0)  # Exit immediately, as a success
           end
+
+  # Aggregate the matrix result into a single check named "IntegrationTest"
+  # that branch protection can require. Behavior:
+  #   - matrix succeeded            -> pass
+  #   - `pkgs: '[]'`                -> pass (no downstream configured)
+  #   - matrix all-skipped + fork   -> fail with /integrationtest hint
+  #   - any failure                 -> fail
+  # The fork-PR-all-skipped case is the trigger for the manual
+  # `/integrationtest <pkg>` flow in IntegrationTestRequest.yml, which
+  # posts a passing check with the same name to satisfy branch protection.
+  gate:
+    name: "IntegrationTest"
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: "Verify integration tests"
+        env:
+          PKGS: ${{ inputs.pkgs }}
+          RESULT: ${{ needs.test.result }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          echo "test.result=$RESULT pkgs=$PKGS event=$EVENT_NAME"
+          if [ "$RESULT" = "success" ]; then
+            exit 0
+          fi
+          if [ "$RESULT" = "skipped" ]; then
+            if [ "$PKGS" = "[]" ]; then
+              echo "No downstream integration tests configured; passing."
+              exit 0
+            fi
+            if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+              echo "::error::All downstream integration tests skipped on this fork PR. A maintainer must run \`/integrationtest <pkg>\` for each private dep before merging."
+              exit 1
+            fi
+            echo "::error::Integration matrix unexpectedly all skipped (event=$EVENT_NAME)."
+            exit 1
+          fi
+          echo "::error::Integration tests did not pass (result=$RESULT)."
+          exit 1

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -83,6 +83,23 @@ jobs:
           fi
           echo "URL '$PKG' needs auth; running with secrets in scope (event '$EVENT_NAME')."
           echo "skip=false" >> "$GITHUB_OUTPUT"
+      - name: "Record skipped dependency"
+        id: skip_artifact
+        if: steps.gate.outputs.skip == 'true'
+        env:
+          PKG: ${{ matrix.pkg }}
+        run: |
+          key=$(printf '%s' "$PKG" | shasum -a 256 | cut -d ' ' -f 1)
+          path="integration-test-skip-${key}.txt"
+          printf '%s\n' "$PKG" > "$path"
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+      - name: "Upload skipped-dependency marker"
+        if: steps.gate.outputs.skip == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-skip-${{ steps.skip_artifact.outputs.key }}
+          path: ${{ steps.skip_artifact.outputs.path }}
       - uses: actions/checkout@v4
         if: steps.gate.outputs.skip != 'true'
         with:
@@ -172,8 +189,16 @@ jobs:
     needs: test
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      actions: read
     steps:
+      - name: "Download skipped-dependency markers"
+        uses: actions/download-artifact@v4
+        with:
+          pattern: integration-test-skip-*
+          path: skipped-integration-tests
+          merge-multiple: true
+        continue-on-error: true
       - name: "Verify integration tests"
         env:
           PKGS: ${{ inputs.pkgs }}
@@ -183,7 +208,20 @@ jobs:
           BASE_REPO: ${{ github.repository }}
         run: |
           echo "test.result=$RESULT pkgs=$PKGS event=$EVENT_NAME"
+          pkg_count=$(printf '%s' "$PKGS" | jq 'length')
+          skipped_count=0
+          if [ -d skipped-integration-tests ]; then
+            skipped_count=$(find skipped-integration-tests -type f | wc -l | tr -d ' ')
+          fi
+          echo "skipped dependency count: $skipped_count / $pkg_count"
           if [ "$RESULT" = "success" ]; then
+            if [ "$skipped_count" -gt 0 ]; then
+              if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" != "$BASE_REPO" ] && [ "$skipped_count" -eq "$pkg_count" ]; then
+                echo "::error::All downstream integration tests skipped on this fork PR. A maintainer must run \`/integrationtest <pkg>\` for each private dep before merging."
+                exit 1
+              fi
+              echo "::notice::$skipped_count downstream integration test(s) skipped because they require authentication in this event context."
+            fi
             exit 0
           fi
           if [ "$RESULT" = "skipped" ]; then

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -13,6 +13,11 @@ on:
         default: ""
         required: false
         type: string
+      extra-dev-paths:
+        description: "Additional local package paths to develop alongside the repository root, specified as a newline-separated list."
+        default: ""
+        required: false
+        type: string
 
 jobs:
   get-pr-comment:
@@ -54,6 +59,7 @@ jobs:
     uses: ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main
     with:
       localregistry: "${{ inputs.localregistry }}"
+      extra-dev-paths: "${{ inputs.extra-dev-paths }}"
       pkgs: ${{ needs.get-pr-comment.outputs.pkgs }}
     secrets: inherit
 

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -17,38 +17,76 @@ on:
 jobs:
   get-pr-comment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
-      pkg: ${{ steps.extract.outputs.PKG }}
+      pkgs: ${{ steps.extract.outputs.pkgs }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
     steps:
       - name: Extract command arguments
         id: extract
+        env:
+          COMMENT: ${{ github.event.comment.body }}
+          QUERY: ${{ inputs.trigger }}
         run: |
-          COMMENT="${{ github.event.comment.body }}"
-          QUERY="${{ inputs.trigger }}"
-          # Check if COMMENT starts with QUERY followed by a space
-          if [[ "$COMMENT" == "$QUERY "* ]]; then
-            # Extract everything after QUERY + space
-            PKG="${COMMENT#"$QUERY "}"
-            echo "PKG=$PKG" >> $GITHUB_OUTPUT
-          else
+          if [[ "$COMMENT" != "$QUERY "* ]]; then
             echo "No valid command found, exiting..."
             exit 1
           fi
+          PKG="${COMMENT#"$QUERY "}"
+          # Encode as a single-element JSON array for the IntegrationTest
+          # workflow's `pkgs` input. `jq` handles any escaping for us.
+          PKGS=$(jq -nc --arg pkg "$PKG" '[$pkg]')
+          echo "pkgs=$PKGS" >> "$GITHUB_OUTPUT"
+      - name: Resolve PR head SHA
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
   runtests:
     needs: get-pr-comment
     uses: ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main
     with:
       localregistry: "${{ inputs.localregistry }}"
-      pkg: "${{ needs.get-pr-comment.outputs.pkg || ''}}"
+      pkgs: ${{ needs.get-pr-comment.outputs.pkgs }}
     secrets: inherit
 
   report:
     needs: [get-pr-comment, runtests]
+    if: ${{ always() && needs.get-pr-comment.result == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
     steps:
-      - uses: peter-evans/create-or-update-comment@v4
+      - name: React to triggering comment
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.INTEGRATIONTEST_PAT || github.token }}
           comment-id: ${{ github.event.comment.id }}
           reactions: '+1'
+      # When the test passed, post a check run with the same name that
+      # branch protection requires for IntegrationTest. This lets a
+      # successful `/integrationtest` clear the IntegrationTest gate on
+      # fork PRs whose private-only matrix would otherwise leave that
+      # gate failing.
+      - name: Post passing IntegrationTest check
+        if: ${{ needs.runtests.result == 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ needs.get-pr-comment.outputs.head_sha }}
+        run: |
+          gh api -X POST "repos/$REPO/check-runs" \
+            -f name="IntegrationTest" \
+            -f head_sha="$HEAD_SHA" \
+            -f status="completed" \
+            -f conclusion="success" \
+            -f "output[title]=Passed via /integrationtest" \
+            -f "output[summary]=Integration test passed when triggered manually."

--- a/.github/workflows/LiterateCheck.yml
+++ b/.github/workflows/LiterateCheck.yml
@@ -29,6 +29,8 @@ jobs:
   literate:
     name: "Literate Check"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -36,6 +38,8 @@ jobs:
           version: "${{ inputs.julia-version }}"
       - name: Setup project
         shell: julia --project=docs --color=yes {0}
+        env:
+          LOCALREGISTRY: ${{ inputs.localregistry }}
         run: |
           import Pkg
           if VERSION >= v"1.8-"
@@ -43,8 +47,9 @@ jobs:
           else
             Pkg.Registry.add("General")
           end
-          if !isempty("${{ inputs.localregistry }}")
-            local_repos = split("${{ inputs.localregistry }}", "\n") .|> string
+          localregistry = get(ENV, "LOCALREGISTRY", "")
+          if !isempty(localregistry)
+            local_repos = split(localregistry, "\n") .|> string
             for repo_url in local_repos
               isempty(repo_url) && continue
               Pkg.Registry.add(Pkg.RegistrySpec(; url=repo_url))

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -34,6 +34,14 @@ jobs:
         contains(github.event.comment.body, inputs.trigger)
       )
 
+    # Writes (commit comment for General path, registry PR for local
+    # path, comment reaction) all use REGISTRATOR_PAT, so this job
+    # itself only needs read scope on the GITHUB_TOKEN. The PAT bypasses
+    # GITHUB_TOKEN's permissions for the actual write operations.
+    permissions:
+      contents: read
+      pull-requests: read
+
     env:
       # Prefer the commit that landed on the base branch when available (merged PRs),
       # otherwise PR head SHA, otherwise github.sha.
@@ -44,12 +52,14 @@ jobs:
         if: github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TRIGGER: ${{ inputs.trigger }}
         run: |
           BODY=$(jq -r '.comment.body' "$GITHUB_EVENT_PATH")
-          SHA=$(printf '%s' "$BODY" | grep -oP '${{ inputs.trigger }}\s+\K[0-9a-f]{7,40}' | head -1 || true)
+          SHA=$(printf '%s' "$BODY" | grep -oP "${TRIGGER}"'\s+\K[0-9a-f]{7,40}' | head -1 || true)
           if [ -n "$SHA" ]; then
-            FULL_SHA=$(gh api repos/${{ github.repository }}/commits/$SHA --jq '.sha')
-            echo "TARGET_SHA=$FULL_SHA" >> $GITHUB_ENV
+            FULL_SHA=$(gh api "repos/$REPO/commits/$SHA" --jq '.sha')
+            echo "TARGET_SHA=$FULL_SHA" >> "$GITHUB_ENV"
           fi
 
       - name: "Setup Julia ${{ inputs.julia-version }}"
@@ -203,13 +213,17 @@ jobs:
       - name: Compose Registrator commit comment
         if: steps.meta.outputs.route == 'general'
         shell: bash
+        env:
+          IS_BREAKING: ${{ steps.meta.outputs.is_breaking }}
+          SUBJECT: ${{ steps.meta.outputs.subject }}
+          NEW_VERSION: ${{ steps.meta.outputs.new_version }}
         run: |
           {
             echo "@JuliaRegistrator register"
-            if [ "${{ steps.meta.outputs.is_breaking }}" = "true" ]; then
+            if [ "$IS_BREAKING" = "true" ]; then
               echo ""
               echo "Release notes:"
-              echo "- breaking: ${{ steps.meta.outputs.subject }} (v${{ steps.meta.outputs.new_version }})"
+              echo "- breaking: $SUBJECT (v$NEW_VERSION)"
             fi
           } > registrator-comment.md
 

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   TagBotITensorRegistry:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: "write"
     steps:
       - uses: "JuliaRegistries/TagBot@v1"
         with:
@@ -22,6 +24,8 @@ jobs:
           registry: "ITensor/ITensorRegistry"
   TagBotGeneral:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: "write"
     steps:
       - uses: "JuliaRegistries/TagBot@v1"
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -108,6 +108,8 @@ on:
 jobs:
   tests:
     name: "Julia ${{ inputs.julia-version }} - ${{ inputs.self-hosted && 'self-hosted' || inputs.os }} ${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
+    permissions:
+      contents: read
     if: >-
       !github.event.pull_request.draft
       || inputs.run-all-on-draft
@@ -120,9 +122,14 @@ jobs:
 
       - name: "Install apt packages"
         if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"
+        env:
+          APT_PACKAGES: ${{ inputs.apt-packages }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y ${{ inputs.apt-packages }}
+          # `apt-get install` accepts a space-separated list; we deliberately
+          # don't quote to allow the multi-package case.
+          # shellcheck disable=SC2086
+          sudo apt-get install -y $APT_PACKAGES
 
       - name: "Setup Julia ${{ inputs.julia-version }}"
         uses: julia-actions/setup-julia@v2
@@ -143,8 +150,10 @@ jobs:
       - name: "Export extra environment variables"
         if: "${{ inputs.extra-env != '' }}"
         shell: "bash"
+        env:
+          EXTRA_ENV: ${{ inputs.extra-env }}
         run: |
-          echo "${{ inputs.extra-env }}" >> "$GITHUB_ENV"
+          printf '%s\n' "$EXTRA_ENV" >> "$GITHUB_ENV"
 
       - name: "Run tests ${{ inputs.self-hosted && '' || format('on {0}', inputs.os) }} with Julia v${{ inputs.julia-version }}"
         uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -18,6 +18,9 @@ jobs:
   version-check:
     name: "Check Versions"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.scripts/release.sh
+++ b/.scripts/release.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# release.sh — tag a versioned release of the ITensorActions reusable
+# workflows and composite actions.
+#
+# Usage:
+#   .scripts/release.sh vX.Y.Z
+#
+# What it does:
+#   1. Verifies the working tree is clean and we are on `main`.
+#   2. Verifies the requested tag does not already exist.
+#   3. On a detached HEAD off the current `main`, rewrites every
+#      internal `ITensor/ITensorActions/.github/{workflows,actions}/...@main`
+#      reference to point at the current `main` commit's SHA. This way
+#      `@vX.Y.Z` callers get a consistent snapshot — the workflow file
+#      they fetch has its own internal `uses:` lines pinned to a fixed
+#      SHA rather than a moving `@main`.
+#   4. Commits the rewrite (the rewrite commit is reachable only via
+#      the tag — `main` itself stays unmodified, so day-to-day
+#      development continues to use `@main`).
+#   5. Tags the rewrite commit as `vX.Y.Z` (annotated, immutable).
+#   6. Updates the mutable major-version tag (`vX`) to point at the
+#      same commit, so callers can pin `@vX` for "latest in this
+#      major version".
+#   7. Prints the push commands; nothing is pushed automatically.
+#
+# Why this exists:
+#   GitHub Actions resolves `uses:` references at workflow-execution
+#   time. A reusable workflow tagged `v1.0.0` whose own internal
+#   references say `@main` would still inherit whatever is on `main`
+#   today, defeating the point of versioning. The rewrite step pins
+#   those internal references at release time so the tagged release
+#   is fully snapshot-stable.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 vX.Y.Z" >&2
+  exit 2
+fi
+
+VERSION="$1"
+
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid version: '$VERSION' (expected vN.N.N)" >&2
+  exit 2
+fi
+
+MAJOR_VERSION="${VERSION%%.*}"  # strips ".Y.Z" → "vX"
+
+# Verify clean working tree.
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Working tree is dirty. Commit, stash, or revert before releasing." >&2
+  exit 2
+fi
+
+# Verify on main.
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  echo "Must be on 'main', not '$CURRENT_BRANCH'." >&2
+  exit 2
+fi
+
+# Verify tag does not already exist.
+if git rev-parse "$VERSION" >/dev/null 2>&1; then
+  echo "Tag '$VERSION' already exists." >&2
+  exit 2
+fi
+
+HEAD_SHA="$(git rev-parse HEAD)"
+echo "Tagging $VERSION; internal refs will be pinned at $HEAD_SHA."
+
+# Work on a detached HEAD so the rewrite commit doesn't pollute main.
+git checkout --quiet --detach HEAD
+
+# Rewrite internal `@main` refs in workflows and composite actions.
+shopt -s nullglob
+files=()
+while IFS= read -r f; do
+  files+=("$f")
+done < <(find .github/workflows .github/actions \
+  -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null)
+
+rewritten=0
+for f in "${files[@]}"; do
+  if grep -qE 'ITensor/ITensorActions/\.github/(workflows|actions)/[^@[:space:]]+@main' "$f"; then
+    # macOS sed needs `-i ''`; GNU sed accepts `-i` alone. Using `-i.bak`
+    # is the most portable form.
+    sed -E -i.bak \
+      "s|(ITensor/ITensorActions/\\.github/(workflows|actions)/[^@[:space:]]+)@main|\\1@${HEAD_SHA}|g" \
+      "$f"
+    rm "$f.bak"
+    rewritten=$((rewritten + 1))
+    echo "  pinned internal refs in $f"
+  fi
+done
+
+if [ "$rewritten" -gt 0 ]; then
+  git add .github
+  git commit --quiet -m "Pin internal references for $VERSION release"
+fi
+
+# Tag (annotated for the immutable release, lightweight for the major tag).
+git tag -a "$VERSION" -m "Release $VERSION"
+
+if git rev-parse "$MAJOR_VERSION" >/dev/null 2>&1; then
+  echo "Updating existing $MAJOR_VERSION mutable tag."
+  git tag -d "$MAJOR_VERSION" >/dev/null
+fi
+git tag "$MAJOR_VERSION"
+
+# Return to the main branch so the rewrite commit is reachable only
+# via the tags.
+git checkout --quiet main
+
+echo
+echo "Created locally:"
+echo "  $VERSION         (annotated, immutable)"
+echo "  $MAJOR_VERSION              (lightweight, mutable; points at $VERSION)"
+echo
+echo "Push with:"
+echo "  git push origin $VERSION"
+echo "  git push --force origin $MAJOR_VERSION   # mutable tag intentionally moves"

--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ The companion `IntegrationTestRequest.yml` workflow (used for the `/integrationt
 |---|---|---|---|
 | `trigger` | string | `"/integrationtest"` | Comment trigger phrase. |
 | `localregistry` | string | `""` | Newline-separated list of extra registry URLs to add before resolving. |
+| `extra-dev-paths` | string | `""` | Newline-separated list of additional local package paths to develop alongside the repository root before resolving downstream tests. |
 
 ### Secrets
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
 # ITensorActions
 
-Shared workflows for the ITensors Julia packages
+Shared workflows for the ITensors Julia packages.
+
+## Versioning
+
+Callers should pin to a major-version tag rather than to `@main`:
+
+```yaml
+uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v1"
+```
+
+Releases follow `vMAJOR.MINOR.PATCH` (e.g. `v1.0.0`, `v1.0.1`,
+`v1.1.0`). A mutable major-version tag (`v1`) is updated to point at
+the latest `v1.x.y` after each release, mirroring the convention
+used by `actions/checkout`, `julia-actions/setup-julia`, and similar
+third-party reusable actions. Callers should reference `@v1` for
+"latest in major version 1"; SHA-pinning to a specific `v1.x.y`
+release is also supported when extra rigor is needed.
+
+Breaking changes (e.g. a renamed input) bump the major version. The
+old major tag stays in place so existing callers keep working until
+they migrate.
+
+To cut a release, run `.scripts/release.sh vX.Y.Z` from a clean
+`main` checkout. The script rewrites internal `@main` references in
+the released commit to the current SHA so the tagged release is a
+fully snapshot-stable bundle (its workflows reference its own
+companion actions at a fixed commit, not at moving `@main`).
 
 ## Tests
 
@@ -200,30 +226,62 @@ There are three workflows available: one for simply verifying the formatting, on
 
 ### Format Check
 
+Format Check is split into two reusable workflows for security: a
+**parse phase** that runs the formatter on the PR head with no
+secrets in scope, and a **postback phase** that runs in the trusted
+base-repo context and posts the format-suggestion comment. Branch
+protection should require the parse phase's check
+(`Format Check / Check Formatting`); the postback exists only to
+update the comment.
+
+The split uses GitHub's standard `pull_request:` + `workflow_run:`
+pattern. See [Securing your GitHub Actions](https://docs.github.com/en/actions/reference/security/secure-use)
+for the rationale: running PR-controlled code (a formatter parsing
+PR source) with `FORMATPULLREQUEST_PAT` in scope would be the same
+risky shape as the IntegrationTest pre-fix configuration.
+
+Add **two** workflow files per repo:
+
 ```yaml
+# .github/workflows/FormatCheck.yml — parse phase
 name: "Format Check"
 
 on:
-  push:
-    branches:
-      - 'main'
-    tags: '*'
   pull_request:
-
-permissions:
-  contents: read
-  actions: write
-  pull-requests: write
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   format-check:
-    name: "Format Check"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v1"
     with:
       directory: "." # Customize this to check a specific directory
 ```
 
-#### Inputs
+```yaml
+# .github/workflows/FormatCheckPostback.yml — postback phase
+name: "Format Check Postback"
+
+on:
+  workflow_run:
+    workflows: ["Format Check"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  postback:
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckPostback.yml@v1"
+    secrets: inherit
+```
+
+The parse-phase workflow uploads the formatter's diff and the PR
+metadata as an artifact named `format-check`; the postback workflow
+downloads it after the parse run completes and posts or updates the
+suggestion comment.
+
+#### Format Check inputs
 
 | Input | Type | Default | Description |
 |---|---|---|---|
@@ -231,6 +289,12 @@ jobs:
 | `julia-version` | string | `"1"` | Julia version passed to `julia-actions/setup-julia`. |
 | `concurrent-jobs` | bool | `false` | When `true`, runs use `github.run_id` as the concurrency group (each run gets its own group). When `false`, runs share `github.ref` and older runs are cancelled. |
 | `cancel-in-progress` | bool | `true` | Whether to cancel in-progress runs in the same concurrency group. Only effective when `concurrent-jobs` is `false`. |
+
+#### Format Check Postback inputs
+
+| Input | Type | Default | Description |
+|---|---|---|---|
+| `check-name` | string | `"Format Check"` | Name of the parse-phase workflow whose `workflow_run` events trigger the postback. Override only if the parse-phase workflow's `name:` differs. |
 
 ### Format Pull Request
 
@@ -364,35 +428,25 @@ Additionally, if some dependent packages being tested are registered in one or m
 local registry, you can specify a list of local registries using their
 repository URLs using the `localregistry` option,
 which should be a string with registry URLs separated by a newline character (`\n`).
-Here is an example workflow:
+The reusable workflow expands its own matrix internally — callers pass the list of
+packages to test as a JSON array via the `pkgs` input. Here is an example:
 
 ```yaml
 name: "IntegrationTest"
 
 on:
   push:
-    branches:
-      - 'main'
-    tags: '*'
-    paths:
-      - 'Project.toml'
+    branches: ["main"]
   pull_request:
-    paths:
-      - 'Project.toml'
+    types: ["opened", "synchronize", "reopened", "ready_for_review", "converted_to_draft"]
 
 jobs:
   integration-test:
-    name: "IntegrationTest"
-    strategy:
-       matrix:
-         pkg:
-           - 'BlockSparseArrays'
-           - 'NamedDimsArrays'
-           - 'TensorAlgebra'
     uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
+    secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
-      pkg: "${{ matrix.pkg }}"
+      pkgs: '["BlockSparseArrays", "NamedDimsArrays", "TensorAlgebra"]'
 ```
 
 The workflow does not run `julia-actions/julia-buildpkg` before testing. It
@@ -412,50 +466,63 @@ repository root:
 ```yaml
 jobs:
   integration-test:
-    name: "IntegrationTest"
-    strategy:
-      matrix:
-        pkg:
-          - 'ITensorMPS'
-          - 'ITensorNetworks'
     uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
-      extra-dev-paths: "NDTensors"
-      pkg: "${{ matrix.pkg }}"
+      pkgs: '["ITensorMPS", "ITensorNetworks"]'
+      extra-dev-paths: |
+        NDTensors
 ```
 
 For multiple extra paths, use a newline-separated string.
 
+The workflow also emits a single `IntegrationTest` check that aggregates the matrix
+result, suitable for use as a required status check in branch protection.
+
+Use `pkgs: '[]'` if no downstream tests are configured; the aggregate check passes.
+
+### Trigger choice: `pull_request` not `pull_request_target`
+
+Use `on: pull_request:` so that fork PRs run without access to repository secrets.
+`pull_request_target:` would expose `INTEGRATIONTEST_PAT` and a write-scope
+`GITHUB_TOKEN` to PR-controlled Julia code (via `Pkg.test`), which is the pattern
+exploited in the 2025 Trivy compromise.
+
+Internal PRs (same-repo branches) still receive secrets under `pull_request:`, so
+no behavior changes for the day-to-day workflow.
+
 ### Private or unregistered packages
 
-You can also test private or unregistered packages by passing a URL as the `pkg` value
-instead of a package name. The workflow detects URLs (starting with `https://` or `git@`)
-and installs the package directly from the URL, skipping the version-pinning logic that
-only applies to registered packages.
+`pkgs` entries may be either registered package names (e.g. `"BlockSparseArrays"`)
+or git URLs (e.g. `"https://github.com/MyOrg/MyPrivatePackage.jl"`,
+`"git@github.com:..."`). The workflow:
 
-For private repositories, pass a GitHub token via `secrets: inherit` — the workflow
-expects it as a secret named `INTEGRATIONTEST_PAT`:
+- Runs registered-name entries normally.
+- Probes URL entries anonymously to detect whether they need authentication.
+  Public URLs run normally on every PR.
+- Skips URL entries that need authentication when the event is a fork
+  `pull_request` (no secrets in scope). The skipped leg emits a notice
+  pointing the maintainer at `/integrationtest <url>` (see below).
+
+For private GitHub repos, configure the `INTEGRATIONTEST_PAT` secret at the
+repository or organization level and pass `secrets: "inherit"`. Internal PRs and
+push events use the PAT to clone; fork PRs do not see the PAT.
 
 ```yaml
 jobs:
   integration-test:
-    name: "IntegrationTest"
-    strategy:
-      matrix:
-        pkg:
-          - 'BlockSparseArrays'
-          - 'https://github.com/MyOrg/MyPrivatePackage.jl'
     uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
-    secrets: inherit
+    secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
-      pkg: "${{ matrix.pkg }}"
+      pkgs: '["BlockSparseArrays", "https://github.com/MyOrg/MyPrivatePackage.jl"]'
 ```
 
-The workflow uses the `INTEGRATIONTEST_PAT` secret for authentication, configured at the
-repository or organization level. When present, it is used to rewrite HTTPS clones of
-GitHub repositories to authenticated URLs so private dependencies can be fetched.
+When a fork PR's matrix is **entirely** private URLs (every leg skipped), the
+aggregate `IntegrationTest` check fails with a message instructing the maintainer
+to run `/integrationtest <url>` for each private dep before merging. The companion
+`IntegrationTestRequest.yml` workflow posts a passing `IntegrationTest` check on
+success, satisfying the gate.
 
 ### Draft PR behavior
 
@@ -495,7 +562,7 @@ jobs:
 | Input | Type | Default | Description |
 |---|---|---|---|
 | `julia-version` | string | `"1"` | Julia version passed to `julia-actions/setup-julia`. |
-| `pkg` | string | **required** | Package name (without `.jl`, e.g. `ITensors` for `ITensors.jl`) or a URL (`https://...` or `git@...`) for private or unregistered packages. |
+| `pkgs` | string | **required** | JSON-array string of registered package names and/or git URLs. Use `'[]'` to configure no downstream tests. |
 | `localregistry` | string | `""` | Newline-separated list of extra registry URLs to add before resolving. |
 | `extra-dev-paths` | string | `""` | Newline-separated list of additional local package paths to develop alongside the repository root before testing downstream packages. |
 | `run-on-draft` | bool | `false` | Run integration tests on draft PRs. When `false`, draft PRs skip integration tests entirely. |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v1"
     with:
       group: "${{ matrix.group }}"
       julia-version: "${{ matrix.version }}"
@@ -119,7 +119,7 @@ This is controlled by the `run-all-on-draft` input (default: `false`). To run
 the full matrix even on draft PRs, set it to `true`:
 
 ```yaml
-    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v1"
     with:
       run-all-on-draft: true
       # ...
@@ -190,7 +190,7 @@ concurrency:
 jobs:
   build-and-deploy-docs:
     name: "Documentation"
-    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v1"
     secrets: "inherit"
 ```
 
@@ -228,10 +228,10 @@ There are three workflows available: one for simply verifying the formatting, on
 
 Format Check is split into two reusable workflows for security: a
 **parse phase** that runs the formatter on the PR head with no
-secrets in scope, and a **postback phase** that runs in the trusted
+secrets in scope, and a **comment phase** that runs in the trusted
 base-repo context and posts the format-suggestion comment. Branch
 protection should require the parse phase's check
-(`Format Check / Check Formatting`); the postback exists only to
+(`Format Check / Check Formatting`); the comment workflow exists only to
 update the comment.
 
 The split uses GitHub's standard `pull_request:` + `workflow_run:`
@@ -240,10 +240,10 @@ for the rationale: running PR-controlled code (a formatter parsing
 PR source) with `FORMATPULLREQUEST_PAT` in scope would be the same
 risky shape as the IntegrationTest pre-fix configuration.
 
-Add **two** workflow files per repo:
+Add two downstream workflow files:
 
 ```yaml
-# .github/workflows/FormatCheck.yml — parse phase
+# .github/workflows/FormatCheck.yml
 name: "Format Check"
 
 on:
@@ -252,34 +252,37 @@ on:
 
 jobs:
   format-check:
+    name: "Format Check"
     uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v1"
     with:
       directory: "." # Customize this to check a specific directory
 ```
 
 ```yaml
-# .github/workflows/FormatCheckPostback.yml — postback phase
-name: "Format Check Postback"
+# .github/workflows/FormatCheckComment.yml
+name: "Format Check Comment"
 
 on:
   workflow_run:
     workflows: ["Format Check"]
     types: [completed]
 
-permissions:
-  pull-requests: write
-  actions: read
-
 jobs:
-  postback:
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckPostback.yml@v1"
+  comment:
+    name: "Format Check Comment"
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+    permissions:
+      pull-requests: write
+      actions: read
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v1"
     secrets: inherit
 ```
 
 The parse-phase workflow uploads the formatter's diff and the PR
-metadata as an artifact named `format-check`; the postback workflow
-downloads it after the parse run completes and posts or updates the
-suggestion comment.
+metadata as an artifact named `format-check`; the comment workflow
+downloads it from a separate `workflow_run` event after the parse run
+completes and posts or updates the suggestion comment.
 
 #### Format Check inputs
 
@@ -290,11 +293,11 @@ suggestion comment.
 | `concurrent-jobs` | bool | `false` | When `true`, runs use `github.run_id` as the concurrency group (each run gets its own group). When `false`, runs share `github.ref` and older runs are cancelled. |
 | `cancel-in-progress` | bool | `true` | Whether to cancel in-progress runs in the same concurrency group. Only effective when `concurrent-jobs` is `false`. |
 
-#### Format Check Postback inputs
+#### Format Check Comment inputs
 
 | Input | Type | Default | Description |
 |---|---|---|---|
-| `check-name` | string | `"Format Check"` | Name of the parse-phase workflow whose `workflow_run` events trigger the postback. Override only if the parse-phase workflow's `name:` differs. |
+| `check-name` | string | `"Format Check"` | Name of the parse-phase workflow whose `workflow_run` events trigger the comment workflow. Override only if the parse-phase workflow's `name:` differs. |
 
 ### Format Pull Request
 
@@ -324,7 +327,7 @@ permissions:
 jobs:
   format-pull-request:
     name: "Format Pull Request"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v1"
     with:
       directory: "." # Customize this to check a specific directory
       # trigger: "/format" # Customize the on-demand trigger phrase (default: "/format")
@@ -356,7 +359,7 @@ on:
 jobs:
   format-check:
     name: "Literate Check"
-    uses: "ITensor/ITensorActions/.github/workflows/LiterateCheck.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/LiterateCheck.yml@v1"
 ```
 
 ### Inputs
@@ -398,7 +401,7 @@ permissions:
 jobs:
   compat-helper:
     name: "CompatHelper"
-    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@v1"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets: inherit
@@ -442,11 +445,17 @@ on:
 
 jobs:
   integration-test:
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
+    name: "IntegrationTest"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
-      pkgs: '["BlockSparseArrays", "NamedDimsArrays", "TensorAlgebra"]'
+      pkgs: |
+        [
+          "BlockSparseArrays",
+          "NamedDimsArrays",
+          "TensorAlgebra"
+        ]
 ```
 
 The workflow does not run `julia-actions/julia-buildpkg` before testing. It
@@ -466,10 +475,15 @@ repository root:
 ```yaml
 jobs:
   integration-test:
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
+    name: "IntegrationTest"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
-      pkgs: '["ITensorMPS", "ITensorNetworks"]'
+      pkgs: |
+        [
+          "ITensorMPS",
+          "ITensorNetworks"
+        ]
       extra-dev-paths: |
         NDTensors
 ```
@@ -511,11 +525,16 @@ push events use the PAT to clone; fork PRs do not see the PAT.
 ```yaml
 jobs:
   integration-test:
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
+    name: "IntegrationTest"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
-      pkgs: '["BlockSparseArrays", "https://github.com/MyOrg/MyPrivatePackage.jl"]'
+      pkgs: |
+        [
+          "BlockSparseArrays",
+          "https://github.com/MyOrg/MyPrivatePackage.jl"
+        ]
 ```
 
 When a fork PR's matrix is **entirely** private URLs (every leg skipped), the
@@ -531,7 +550,7 @@ controlled by the `run-on-draft` input (default: `false`). To run integration
 tests even on draft PRs, set it to `true`:
 
 ```yaml
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
     with:
       run-on-draft: true
       # ...
@@ -552,7 +571,7 @@ jobs:
     if: |
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
-    uses: ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@main
+    uses: ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v1
     with:
       localregistry: https://github.com/ITensor/ITensorRegistry.git
 ```
@@ -595,7 +614,7 @@ on:
 jobs:
   version-check:
     name: "Version Check"
-    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v1"
     with:
       localregistry: https://github.com/ITensor/ITensorRegistry.git
 ```
@@ -639,7 +658,7 @@ on:
 jobs:
   check-compat-bounds:
     name: "Check Compat Bounds"
-    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v1"
     with:
       localregistry: https://github.com/ITensor/ITensorRegistry.git
 ```
@@ -661,7 +680,7 @@ jobs:
 Example — restrict the check to CompatHelper/Dependabot PRs only:
 
 ```yaml
-    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v1"
     with:
       mode: auto
 ```
@@ -735,7 +754,7 @@ permissions:
 
 jobs:
   Register:
-    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@v1"
     with:
       localregistry: "ITensor/ITensorRegistry" # omit if package is in General
     secrets: "inherit"
@@ -792,7 +811,7 @@ env:
 jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
-    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v1"
     secrets: inherit
 ```
 
@@ -842,7 +861,7 @@ env:
 jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
-    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v1"
     with:
       subdirs: '["NDTensors"]'
     secrets: inherit


### PR DESCRIPTION
## Summary

Restructures the `IntegrationTest`, `IntegrationTestRequest`, and `FormatCheck` reusable workflows to reduce GitHub Actions trust-boundary risk, and introduces a versioning convention so callers can pin to `@v1` instead of `@main`.

### IntegrationTest

- Matrix expansion and the aggregation gate move into the reusable. Input changes from `pkg:` (scalar) to `pkgs:` (JSON array).
- URL-based entries are probed anonymously with `git ls-remote` before secrets are used. Public URLs and registered package names run normally. Private URL entries are skipped on fork `pull_request` events, where secrets are not in scope.
- Skipped private URL legs upload marker artifacts. The aggregate `IntegrationTest` gate inspects those markers and fails when every downstream leg skipped on a fork PR, with a `/integrationtest <url>` instruction.
- The caller-level `pull_request_target:` trigger is no longer needed for migrated repositories; callers should use `pull_request:`.

### IntegrationTestRequest

- Comment-body parsing moves from direct shell interpolation to an `env:` mapping.
- The requested package is JSON-encoded into the new `pkgs` array input.
- On a successful manual run, the workflow posts a passing `IntegrationTest` check run for the PR head SHA, allowing a maintainer-triggered private integration test to clear the gate.

### FormatCheck

- `FormatCheck.yml` is now the read-only parse phase. It runs on `pull_request`, checks out PR code without secrets, runs the formatter, uploads the diff and PR metadata as an artifact, and reports the branch-protection check.
- `FormatCheckComment.yml` is the trusted comment phase. It runs after the parse workflow via `workflow_run`, downloads the artifact, and posts or updates the format-suggestion comment without checking out PR code.
- Branch protection should require the parse-phase check (`Format Check / Check Formatting`); the comment workflow exists only to update the PR comment.

### Hygiene Across The Rest Of The Reusables

- Direct `${{ inputs.* }}` shell interpolations were moved to `env:` mappings in the reusable workflows.
- Explicit per-job `permissions:` blocks were added where they were missing.
- Mutable `@latest` action references in this repository were removed.

### Versioning

- The README documents the `vMAJOR.MINOR.PATCH` release tag plus mutable `vMAJOR` tag convention.
- `.scripts/release.sh` creates release tags locally and rewrites internal `@main` references in the tagged commit to a fixed SHA so tagged releases are snapshot-stable.

## Breaking Change

The `IntegrationTest` reusable input changes from `pkg:` to `pkgs:`. Per-repo callers need to update to the new JSON-array form.

## Test Plan

- [ ] Open a canary PR against a public-matrix repo, pointing callers at this PR's head SHA. Verify the public downstream matrix runs and the aggregate `IntegrationTest` check passes.
- [ ] Open a canary PR against a Tennis-using repo. Verify internal PRs can run private URL integration tests and fork PRs require `/integrationtest`.
- [ ] Verify `FormatCheck` runs from `pull_request` without secrets and that `FormatCheckComment` posts or updates the formatting comment once the comment workflow exists on the target repository's default branch.
- [ ] Run `.scripts/release.sh v1.0.0` locally after merge and confirm it creates the expected `v1.0.0` and `v1` tags without pushing.
