### PR TITLE
Update IntegrationTest dev path handling

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -17,6 +17,11 @@ on:
         default: ""
         required: false
         type: string
+      extra-dev-paths:
+        description: "Additional local package paths to develop alongside the repository root, specified as a newline-separated list."
+        default: ""
+        required: false
+        type: string
       run-on-draft:
         description: "When true, run integration tests even on draft PRs"
         default: false
@@ -50,10 +55,6 @@ jobs:
         with:
           version: ${{ inputs.julia-version }}
           arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-        if: inputs.pkg != '__none__'
-        with:
-          localregistry: "${{ inputs.localregistry }}"
       - name: "Configure git authentication for private repository"
         if: inputs.pkg != '__none__'
         env:
@@ -68,8 +69,11 @@ jobs:
       - name: Run the downstream tests
         if: inputs.pkg != '__none__'
         shell: julia --color=yes --project=downstream {0}
+        env:
+          JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
         run: |
           using Pkg
+          Pkg.Registry.add("General")
           # If provided add local registries
           if !isempty("${{ inputs.localregistry }}")
             registry_urls = split("${{ inputs.localregistry }}", "\n") .|> string
@@ -78,13 +82,16 @@ jobs:
               Pkg.Registry.add(Pkg.RegistrySpec(; url=registry_url))
             end
           end
+          dev_paths = [".", split("${{ inputs['extra-dev-paths'] }}", "\n")...]
+          filter!(!isempty, dev_paths)
+          dev_specs = [PackageSpec(; path) for path in dev_paths]
           pkg = "${{ inputs.pkg }}"
           try
             if startswith(pkg, "https://") || startswith(pkg, "git@")
               # URL: unregistered or private package, skip version-pinning.
               pkg_name = replace(basename(pkg), r"\.jl$" => "")
               Pkg.add(PackageSpec(; url=pkg))  # resolver may fail with main deps
-              Pkg.develop(PackageSpec(; path="."))  # resolver may fail with main deps
+              Pkg.develop(dev_specs)  # resolver may fail with main deps
               Pkg.update()
               Pkg.test(PackageSpec(; name=pkg_name))  # resolver may fail with test time deps
             else
@@ -94,7 +101,7 @@ jobs:
               eval(Expr(:using, :($(Expr(:., Symbol(pkg))))))
               version = pkgversion(eval(Symbol(pkg)))
               # force it to use this PR's version of the package
-              Pkg.develop(PackageSpec(; path="."))  # resolver may fail with main deps
+              Pkg.develop(dev_specs)  # resolver may fail with main deps
               Pkg.update()
               # Try forcing the installation of the package at the latest version
               # to see if there is a compatibility issue.

--- a/README.md
+++ b/README.md
@@ -362,8 +362,8 @@ since it is safe to register the changes without breaking downstream
 packages if they follow semver in their compat versions.
 Additionally, if some dependent packages being tested are registered in one or more
 local registry, you can specify a list of local registries using their
-repository URLs using the `localregisty` option,
-which should be a string with registry URLs seperated by a newline character (`\n`).
+repository URLs using the `localregistry` option,
+which should be a string with registry URLs separated by a newline character (`\n`).
 Here is an example workflow:
 
 ```yaml
@@ -394,6 +394,38 @@ jobs:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
       pkg: "${{ matrix.pkg }}"
 ```
+
+The workflow does not run `julia-actions/julia-buildpkg` before testing. It
+tests downstream packages in a separate `downstream` project, where the package
+under test is developed from the PR checkout before the downstream tests run.
+The package's own test workflow should be responsible for checking that the
+package itself builds and tests successfully.
+
+### Developing additional local package paths
+
+Some repositories contain multiple packages that should be developed together
+when testing downstream packages. For example, a parent package may depend on
+an in-repository subpackage whose new version has not been registered yet. Use
+`extra-dev-paths` to develop additional local package paths alongside the
+repository root:
+
+```yaml
+jobs:
+  integration-test:
+    name: "IntegrationTest"
+    strategy:
+      matrix:
+        pkg:
+          - 'ITensorMPS'
+          - 'ITensorNetworks'
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
+    with:
+      localregistry: "https://github.com/ITensor/ITensorRegistry.git"
+      extra-dev-paths: "NDTensors"
+      pkg: "${{ matrix.pkg }}"
+```
+
+For multiple extra paths, use a newline-separated string.
 
 ### Private or unregistered packages
 
@@ -465,6 +497,7 @@ jobs:
 | `julia-version` | string | `"1"` | Julia version passed to `julia-actions/setup-julia`. |
 | `pkg` | string | **required** | Package name (without `.jl`, e.g. `ITensors` for `ITensors.jl`) or a URL (`https://...` or `git@...`) for private or unregistered packages. |
 | `localregistry` | string | `""` | Newline-separated list of extra registry URLs to add before resolving. |
+| `extra-dev-paths` | string | `""` | Newline-separated list of additional local package paths to develop alongside the repository root before testing downstream packages. |
 | `run-on-draft` | bool | `false` | Run integration tests on draft PRs. When `false`, draft PRs skip integration tests entirely. |
 
 The companion `IntegrationTestRequest.yml` workflow (used for the `/integrationtest ...` comment trigger shown above) has its own inputs:


### PR DESCRIPTION
## Summary

- remove the pre-test julia-buildpkg step from the reusable IntegrationTest workflow
- add an extra-dev-paths input for repositories that need to develop additional local package paths alongside the root package
- document the new IntegrationTest behavior and input in the README

## Rationale

Reverse-dependency integration tests run downstream test suites in an isolated downstream project after developing the package under test. Pre-building the root project can fail before the workflow has a chance to develop related in-repository packages, which prevents the integration test from reaching the resolver behavior it is meant to check.

## Checks

- pre-commit run --files README.md .github/workflows/IntegrationTest.yml
- YAML parse of .github/workflows/IntegrationTest.yml
- git diff --check