### PR TITLE
CompatHelper: guard against JSON error body in TOKEN_OWNER

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -107,6 +107,10 @@ jobs:
           end
           subdirs = ["", "docs", "examples", "test"]
           token_owner = get(ENV, "TOKEN_OWNER", "")
+          # If TOKEN_OWNER contains a JSON error body (happens when only GITHUB_TOKEN
+          # is available, e.g. in private repos without COMPATHELPER_PAT), treat it as
+          # empty so CompatHelper falls back to the default "github-actions[bot]" username.
+          startswith(token_owner, '{') && (token_owner = "")
           ci_cfg = isempty(token_owner) ?
               CompatHelper.GitHubActions() :
               CompatHelper.GitHubActions(; username=token_owner)


### PR DESCRIPTION
When `COMPATHELPER_PAT` is not available (e.g. private repos on the free plan), `gh api user` returns a 403 JSON body. That body was being passed as the dedup username to `CompatHelper.GitHubActions(; username=...)` because `isempty` returned false on the non-empty JSON string. This caused CompatHelper to open a new duplicate PR on every daily run.

Fix: if `TOKEN_OWNER` starts with `{`, treat it as empty and fall back to the default `github-actions[bot]` username.