### PR TITLE
Docs: make SemVer release decision policy explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ third-party reusable actions. Callers should reference `@v1` for
 "latest in major version 1"; SHA-pinning to a specific `v1.x.y`
 release is also supported when extra rigor is needed.
 
+SemVer release decision rule:
+
+- Patch (`v1.0.x`): bug fixes, docs-only improvements, or internal
+  hardening that does not change caller-facing workflow interfaces.
+- Minor (`v1.x.0`): backward-compatible new inputs, new reusable
+  workflows, or additive behavior.
+- Major (`v2.0.0`): breaking caller-facing changes (renamed/removed
+  inputs, changed required secrets/permissions, incompatible behavior).
+
+Each released commit should be assigned exactly one of the three bump
+types above. Keep `v1.0.0`, `v1.1.0`, etc. immutable; move the mutable
+`v1` tag to the newest `v1.x.y` release.
+
 Breaking changes (e.g. a renamed input) bump the major version. The
 old major tag stays in place so existing callers keep working until
 they migrate.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Each released commit should be assigned exactly one of the three bump
 types above. Keep `v1.0.0`, `v1.1.0`, etc. immutable; move the mutable
 `v1` tag to the newest `v1.x.y` release.
 
+Docs-only PRs (for example README clarifications that do not change
+workflow behavior) do not require a SemVer release, do not require a
+new `v1.x.y` tag, and should not move `v1`.
+
 Breaking changes (e.g. a renamed input) bump the major version. The
 old major tag stays in place so existing callers keep working until
 they migrate.


### PR DESCRIPTION
Clarifies the release-versioning policy in the Versioning section:

- Explicit patch/minor/major decision criteria for workflow changes
- Explicit requirement to keep v1.x.y tags immutable
- Explicit requirement to move the mutable v1 tag to the latest v1.x.y release