### PR TITLE
Treat empty integration package lists as pass

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -209,6 +209,10 @@ jobs:
         run: |
           echo "test.result=$RESULT pkgs=$PKGS event=$EVENT_NAME"
           pkg_count=$(printf '%s' "$PKGS" | jq 'length')
+          if [ "$PKGS" = "[]" ]; then
+            echo "No downstream integration tests configured; passing."
+            exit 0
+          fi
           skipped_count=0
           if [ -d skipped-integration-tests ]; then
             skipped_count=$(find skipped-integration-tests -type f | wc -l | tr -d ' ')


### PR DESCRIPTION
## Summary
- pass integration gate immediately when  is 
- avoid false failures when no downstream integration tests are configured

## Motivation
Some callers intentionally pass an empty package list. In that case there is nothing to run, so the aggregate IntegrationTest check should pass.

## Validation
- reproduced failure in ITensorPkgSkeleton PR where  and gate saw 
- updated gate logic to short-circuit success for 