### PR TITLE
Documentation: render doc-prefix directly to preserve shell quoting

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -110,10 +110,19 @@ jobs:
       - name: Setup project
         shell: "bash"
         env:
-          DOC_PREFIX: ${{ inputs.doc-prefix }}
           LOCALREGISTRY: ${{ inputs.localregistry }}
+        # `doc-prefix` is rendered directly into the script body so that any
+        # shell quoting in the caller's value (e.g. the single-quoted server
+        # args of `xvfb-run -a -s '-screen 0 1024x768x24'`) is parsed by the
+        # shell with normal quoting rules. Routing it through a `$DOC_PREFIX`
+        # env-var would word-split the literal characters of the value
+        # (including any embedded `'`/`"`/`&`/`;`) instead, breaking commands
+        # like xvfb-run that take a quoted multi-word arg. The audit's
+        # env-mapping pattern is for protecting against untrusted
+        # user-controlled input; reusable-workflow inputs come from the
+        # trusted caller workflow file, so direct substitution is fine here.
         run: |
-          ${DOC_PREFIX}julia --project=docs --color=yes <<'EOF'
+          ${{ inputs.doc-prefix }}julia --project=docs --color=yes <<'EOF'
           import Pkg
           if VERSION >= v"1.8-"
             Pkg.Registry.add()
@@ -134,10 +143,11 @@ jobs:
       - name: "Build and Deploy Documentation"
         env:
           GITHUB_TOKEN: ${{ inputs.github-token || secrets.GITHUB_TOKEN }}
-          DOC_PREFIX: ${{ inputs.doc-prefix }}
           JULIA_DEBUG: ${{ inputs.debug-documenter && 'Documenter' || '' }}
           COVERAGE_FLAG: ${{ inputs.coverage && '--code-coverage=user' || '' }}
-        run: ${DOC_PREFIX}julia --project=docs/ $COVERAGE_FLAG docs/make.jl
+        # `doc-prefix` is rendered directly here — see the rationale on the
+        # "Setup project" step above.
+        run: ${{ inputs.doc-prefix }}julia --project=docs/ $COVERAGE_FLAG docs/make.jl
 
       - uses: julia-actions/julia-processcoverage@v1
         if: "${{ inputs.coverage }}"


### PR DESCRIPTION
## Summary

PR #88 routed `inputs.doc-prefix` through a `$DOC_PREFIX` env-var as part of the broader audit hygiene pass that moved `${{ inputs.* }}` shell interpolations to env mappings. For `doc-prefix` specifically, that broke any value containing internal shell quoting — most notably the standard xvfb-run invocation `xvfb-run -a -s '-screen 0 1024x768x24'`.

When a `${VAR}` env expansion is followed by word-splitting in bash, literal `'` characters in the variable value stay literal — they do not regain shell-quoting meaning. So xvfb-run sees `-s '-screen` as one arg and `0` as the next arg (the command to run) and fails with `xvfb-run: 184: 0: not found`. The same hazard applies to any caller value containing literal quotes, `&`, `;`, or other shell metacharacters that should retain their original parsing.

Render `inputs.doc-prefix` directly into the run script body so the shell parses the caller's value with normal quoting rules. Add a comment on each affected step explaining why this one input is intentionally rendered directly so future maintainers don't sweep it back into the env-mapping pattern.

## Why this is safe (security note)

The audit's env-mapping pattern protects against **user-controlled** input — values that originate from PR titles, comment bodies, issue text, etc. (`${{ github.event.* }}` and downstream).

`inputs.doc-prefix` is a **caller-controlled** input: its value is set by the calling workflow file's `with: doc-prefix: "..."` line, which lives in the trusted repository source on a protected branch. Forks cannot modify it (GitHub uses the base-branch workflow file for `pull_request:`/`pull_request_target:` events). So routing it through env vs. template is a security wash for the threats the audit targets.

`localregistry`, `extra-env`, `JULIA_DEBUG`, and the rest of the env-mapped inputs are unaffected and stay as-is.

## Followup (deferred)

A genuinely-tighter design replaces the shell-text knob with a structured input (e.g. `xvfb: true|false`) so the reusable handles xvfb internally and there's no caller-supplied shell text to splice. Same pattern would apply to `apt-packages`. Tracked in the security audit plan as a deferred hardening item; out of scope for this PR.