### PR TITLE
IntegrationTest: skip matrix job when pkgs is empty

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -35,7 +35,15 @@ on:
 jobs:
   test:
     name: ${{ matrix.pkg }}
-    if: "!github.event.pull_request.draft || inputs.run-on-draft"
+    # Skip the matrix-driven leg entirely when `pkgs` is empty. Without this
+    # guard, GitHub Actions reports an empty-matrix job as `failure`, which
+    # propagates to the run's overall conclusion even though the aggregating
+    # `gate` job correctly handles empty `pkgs` by exiting 0. Using
+    # `fromJSON(inputs.pkgs)[0] != null` rather than a string comparison so
+    # the check is robust against whitespace / block-scalar style.
+    if: |
+      fromJSON(inputs.pkgs)[0] != null &&
+      (!github.event.pull_request.draft || inputs.run-on-draft)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

When a caller workflow passes `pkgs: '[]'` (no downstream packages configured), GitHub Actions reports the matrix-driven `test` job as `failure` rather than `skipped`. That conclusion propagates to the workflow run's overall conclusion. The aggregating `gate` job already exits 0 in that case (via the `pkg_count -eq 0` early exit), so the gate's check-run is `success` — but the workflow run as a whole reports `failure`, which surfaces in the Actions tab and email notifications even though branch-protection-required checks are green.

## Fix

Skip the matrix-driven `test` job entirely when `pkgs` is empty so its result is `skipped` rather than `failure`. The `gate` job still exits 0 on empty `pkgs` as before, and now the workflow run's overall conclusion correctly reflects that there's nothing to do.

The new `if:` condition uses `fromJSON(inputs.pkgs)[0] != null` rather than a string comparison so the check is robust against whitespace and block-scalar style in the caller's `pkgs` value.

## Where this surfaced

`ITensor/ITensorPkgSkeleton.jl`'s push-to-main runs of IntegrationTest have been showing as `failure` despite the gate succeeding. Same shape applies to any caller with `pkgs: '[]'` (the leaf packages with no downstream consumers). Branch protection wasn't affected because it requires the `IntegrationTest / IntegrationTest` gate-job context, which is correctly green; the failure was only visible at the workflow-run level.