### PR TITLE
v2: rename reusable workflows to match filenames

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -1,4 +1,4 @@
-name: "Reusable Check Compat Bounds Workflow"
+name: "CheckCompatBounds"
 
 on:
   workflow_call:
@@ -51,7 +51,7 @@ on:
 
 jobs:
   check-compat-bounds:
-    name: "Check Compat Bounds"
+    name: "CheckCompatBounds"
     if: "${{ !github.event.pull_request.draft || inputs.run-on-draft }}"
     runs-on: "ubuntu-latest"
     timeout-minutes: ${{ inputs.timeout-minutes }}

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,4 +1,4 @@
-name: "Reusable CompatHelper Workflow"
+name: "CompatHelper"
 
 on:
   workflow_call:
@@ -16,7 +16,8 @@ on:
         type: string
 
 jobs:
-  CompatHelper:
+  compathelper:
+    name: "CompatHelper"
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,4 +1,4 @@
-name: "Reusable Documentation Build and Deploy Workflow"
+name: "Documentation"
 
 on:
   workflow_call:
@@ -71,8 +71,8 @@ on:
         required: false
 
 jobs:
-  tests:
-    name: "Build and Deploy Documentation"
+  documentation:
+    name: "Documentation"
     continue-on-error: ${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
     permissions:

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,4 +1,4 @@
-name: "Reusable Format Checking Workflow"
+name: "FormatCheck"
 
 # Parse phase of the format-check pipeline. Designed to run on
 # `pull_request:` (no secrets, read-only `GITHUB_TOKEN` for fork PRs)
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   format-check:
-    name: "Check Formatting"
+    name: "FormatCheck"
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/FormatCheckComment.yml
+++ b/.github/workflows/FormatCheckComment.yml
@@ -1,4 +1,4 @@
-name: "Reusable Format Check Comment Workflow"
+name: "FormatCheckComment"
 
 # Comment phase of the format-check pipeline. Triggered by a `workflow_run`
 # event after FormatCheck.yml completes. Runs in the base repo's trusted
@@ -20,8 +20,8 @@ on:
         type: string
 
 jobs:
-  comment:
-    name: "Post format-check comment"
+  format-check-comment:
+    name: "FormatCheckComment"
     # Only run when the parse-phase workflow that triggered us is the
     # expected FormatCheck workflow on a pull_request event.
     if: >-

--- a/.github/workflows/FormatCheckComment.yml
+++ b/.github/workflows/FormatCheckComment.yml
@@ -15,7 +15,7 @@ on:
     inputs:
       check-name:
         description: "Name of the parse-phase workflow this comment workflow runs after. Used to filter unrelated workflow_run events."
-        default: "Format Check"
+        default: "FormatCheck"
         required: false
         type: string
 

--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -1,4 +1,4 @@
-name: "Reusable Format Pull Request Workflow"
+name: "FormatPullRequest"
 
 on:
   workflow_call:
@@ -21,7 +21,7 @@ on:
 
 jobs:
   format-pull-request:
-    name: "Format Pull Request"
+    name: "FormatPullRequest"
     runs-on: ubuntu-latest
     if: |
       github.event_name != 'issue_comment' || (

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -1,4 +1,4 @@
-name: "Reusable IntegrationTest Workflow"
+name: "IntegrationTest"
 
 on:
   workflow_call:
@@ -33,7 +33,7 @@ on:
         required: false
 
 jobs:
-  test:
+  integration-test:
     name: ${{ matrix.pkg }}
     # Skip the matrix-driven leg entirely when `pkgs` is empty. Without this
     # guard, GitHub Actions reports an empty-matrix job as `failure`, which
@@ -194,7 +194,7 @@ jobs:
   # posts a passing check with the same name to satisfy branch protection.
   gate:
     name: "IntegrationTest"
-    needs: test
+    needs: integration-test
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -210,7 +210,7 @@ jobs:
       - name: "Verify integration tests"
         env:
           PKGS: ${{ inputs.pkgs }}
-          RESULT: ${{ needs.test.result }}
+          RESULT: ${{ needs.integration-test.result }}
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -1,4 +1,4 @@
-name: "Reusable Integration Test Request"
+name: "IntegrationTestRequest"
 
 on:
   workflow_call:
@@ -54,7 +54,7 @@ jobs:
           HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
-  runtests:
+  run-tests:
     needs: get-pr-comment
     uses: ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main
     with:
@@ -64,7 +64,7 @@ jobs:
     secrets: inherit
 
   report:
-    needs: [get-pr-comment, runtests]
+    needs: [get-pr-comment, run-tests]
     if: ${{ always() && needs.get-pr-comment.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
@@ -83,7 +83,7 @@ jobs:
       # fork PRs whose private-only matrix would otherwise leave that
       # gate failing.
       - name: Post passing IntegrationTest check
-        if: ${{ needs.runtests.result == 'success' }}
+        if: ${{ needs.run-tests.result == 'success' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -1,4 +1,4 @@
-name: "Reusable Registrator Workflow"
+name: "Registrator"
 
 on:
   workflow_call:
@@ -25,7 +25,7 @@ on:
 
 jobs:
   registrator:
-    name: "Register package version"
+    name: "Registrator"
     runs-on: ubuntu-latest
     if: |
       github.event_name != 'issue_comment' || (

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,4 +1,4 @@
-name: "Reusable TagBot Workflow"
+name: "TagBot"
 
 on:
   workflow_call:
@@ -13,7 +13,8 @@ on:
         required: false
 
 jobs:
-  TagBotITensorRegistry:
+  tagbot-itensor-registry:
+    name: "TagBot (ITensorRegistry)"
     runs-on: "ubuntu-latest"
     permissions:
       contents: "write"
@@ -22,7 +23,8 @@ jobs:
         with:
           token: "${{ secrets.TAGBOT_PAT || github.token }}"
           registry: "ITensor/ITensorRegistry"
-  TagBotGeneral:
+  tagbot-general:
+    name: "TagBot (General)"
     runs-on: "ubuntu-latest"
     permissions:
       contents: "write"
@@ -30,7 +32,8 @@ jobs:
       - uses: "JuliaRegistries/TagBot@v1"
         with:
           token: "${{ secrets.TAGBOT_PAT || github.token }}"
-  TagBotGeneralSubdirs:
+  tagbot-general-subdirs:
+    name: "TagBot (General subdirs)"
     if: "${{ inputs.subdirs != '[]' }}"
     runs-on: "ubuntu-latest"
     permissions:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,4 +1,4 @@
-name: "Reusable Tests Workflow"
+name: "Tests"
 
 on:
   workflow_call:

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -1,4 +1,4 @@
-name: "Reusable Version Checking Workflow"
+name: "VersionCheck"
 
 on:
   workflow_call:
@@ -16,7 +16,7 @@ on:
 
 jobs:
   version-check:
-    name: "Check Versions"
+    name: "VersionCheck"
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Shared workflows for the ITensors Julia packages.
 Callers should pin to a major-version tag rather than to `@main`:
 
 ```yaml
-uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v1"
+uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v2"
 ```
 
 Releases follow `vMAJOR.MINOR.PATCH` (e.g. `v1.0.0`, `v1.0.1`,
 `v1.1.0`). A mutable major-version tag (`v1`) is updated to point at
 the latest `v1.x.y` after each release, mirroring the convention
 used by `actions/checkout`, `julia-actions/setup-julia`, and similar
-third-party reusable actions. Callers should reference `@v1` for
+third-party reusable actions. Callers should reference `@v2` for
 "latest in major version 1"; SHA-pinning to a specific `v1.x.y`
 release is also supported when extra rigor is needed.
 
@@ -117,7 +117,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v2"
     with:
       group: "${{ matrix.group }}"
       julia-version: "${{ matrix.version }}"
@@ -136,7 +136,7 @@ This is controlled by the `run-all-on-draft` input (default: `false`). To run
 the full matrix even on draft PRs, set it to `true`:
 
 ```yaml
-    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v2"
     with:
       run-all-on-draft: true
       # ...
@@ -207,7 +207,7 @@ concurrency:
 jobs:
   build-and-deploy-docs:
     name: "Documentation"
-    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v2"
     secrets: "inherit"
 ```
 
@@ -248,7 +248,7 @@ Format Check is split into two reusable workflows for security: a
 secrets in scope, and a **comment phase** that runs in the trusted
 base-repo context and posts the format-suggestion comment. Branch
 protection should require the parse phase's check
-(`Format Check / Check Formatting`); the comment workflow exists only to
+(`FormatCheck / FormatCheck`); the comment workflow exists only to
 update the comment.
 
 The split uses GitHub's standard `pull_request:` + `workflow_run:`
@@ -270,7 +270,7 @@ on:
 jobs:
   format-check:
     name: "Format Check"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v2"
     with:
       directory: "." # Customize this to check a specific directory
 ```
@@ -292,7 +292,7 @@ jobs:
     permissions:
       pull-requests: write
       actions: read
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v2"
     secrets: inherit
 ```
 
@@ -344,7 +344,7 @@ permissions:
 jobs:
   format-pull-request:
     name: "Format Pull Request"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v2"
     with:
       directory: "." # Customize this to check a specific directory
       # trigger: "/format" # Customize the on-demand trigger phrase (default: "/format")
@@ -376,7 +376,7 @@ on:
 jobs:
   format-check:
     name: "Literate Check"
-    uses: "ITensor/ITensorActions/.github/workflows/LiterateCheck.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/LiterateCheck.yml@v2"
 ```
 
 ### Inputs
@@ -418,7 +418,7 @@ permissions:
 jobs:
   compat-helper:
     name: "CompatHelper"
-    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets: inherit
@@ -463,7 +463,7 @@ on:
 jobs:
   integration-test:
     name: "IntegrationTest"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v2"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
@@ -493,7 +493,7 @@ repository root:
 jobs:
   integration-test:
     name: "IntegrationTest"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v2"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
       pkgs: |
@@ -543,7 +543,7 @@ push events use the PAT to clone; fork PRs do not see the PAT.
 jobs:
   integration-test:
     name: "IntegrationTest"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v2"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
@@ -567,7 +567,7 @@ controlled by the `run-on-draft` input (default: `false`). To run integration
 tests even on draft PRs, set it to `true`:
 
 ```yaml
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v2"
     with:
       run-on-draft: true
       # ...
@@ -588,7 +588,7 @@ jobs:
     if: |
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
-    uses: ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v1
+    uses: ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v2
     with:
       localregistry: https://github.com/ITensor/ITensorRegistry.git
 ```
@@ -631,7 +631,7 @@ on:
 jobs:
   version-check:
     name: "Version Check"
-    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v2"
     with:
       localregistry: https://github.com/ITensor/ITensorRegistry.git
 ```
@@ -675,7 +675,7 @@ on:
 jobs:
   check-compat-bounds:
     name: "Check Compat Bounds"
-    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v2"
     with:
       localregistry: https://github.com/ITensor/ITensorRegistry.git
 ```
@@ -697,7 +697,7 @@ jobs:
 Example — restrict the check to CompatHelper/Dependabot PRs only:
 
 ```yaml
-    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v2"
     with:
       mode: auto
 ```
@@ -771,7 +771,7 @@ permissions:
 
 jobs:
   Register:
-    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@v2"
     with:
       localregistry: "ITensor/ITensorRegistry" # omit if package is in General
     secrets: "inherit"
@@ -828,7 +828,7 @@ env:
 jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
-    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v2"
     secrets: inherit
 ```
 
@@ -878,7 +878,7 @@ env:
 jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
-    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v2"
     with:
       subdirs: '["NDTensors"]'
     secrets: inherit


### PR DESCRIPTION
## Summary

Standardize naming across all reusable workflows so each workflow's top-level `name:` and primary inner-job display `name:` match the file's basename. Job keys are kebab-case lowercase, with brand names like `tagbot`/`compathelper` treated as single words rather than split on internal capitals.

This is a **breaking change** for callers' branch-protection rulesets: the resulting check-context strings shift from e.g. `Format Check / Check Formatting` to `FormatCheck / FormatCheck`. Mark this release as `v2.0.0`. Existing callers pinned to `@v1` continue to work; an ecosystem-wide sweep to update callers from `@v1` to `@v2`, including matching ruleset updates, follows separately.

## Per-workflow rename

| File | Workflow `name:` | Job key | Job display |
|---|---|---|---|
| `CheckCompatBounds` | `CheckCompatBounds` | `check-compat-bounds` ✓ | `CheckCompatBounds` |
| `CompatHelper` | `CompatHelper` | `CompatHelper` → `compathelper` | (added) `CompatHelper` |
| `Documentation` | `Documentation` | `tests` → `documentation` | `Documentation` |
| `FormatCheck` | `FormatCheck` | `format-check` ✓ | `FormatCheck` |
| `FormatCheckComment` | `FormatCheckComment` | `comment` → `format-check-comment` | `FormatCheckComment` |
| `FormatPullRequest` | `FormatPullRequest` | `format-pull-request` ✓ | `FormatPullRequest` |
| `IntegrationTest` | `IntegrationTest` ✓ | `test` → `integration-test`, `gate` ✓ | matrix: `${{ matrix.pkg }}` (kept), gate: `IntegrationTest` ✓ |
| `IntegrationTestRequest` | `IntegrationTestRequest` | `runtests` → `run-tests`; others ✓ | (kept) |
| `Registrator` | `Registrator` | `registrator` ✓ | `Registrator` |
| `TagBot` | `TagBot` ✓ | `TagBot*` → `tagbot-itensor-registry` / `tagbot-general` / `tagbot-general-subdirs` | (added) `TagBot (ITensorRegistry)`, `TagBot (General)`, `TagBot (General subdirs)` |
| `Tests` | `Tests` ✓ | `tests` ✓ | (kept matrix-driven `Julia X - os`) |
| `VersionCheck` | `VersionCheck` | `version-check` ✓ | `VersionCheck` |

`LiterateCheck` is intentionally untouched — already tracked for deletion in a separate cleanup.

## Cross-references updated

Beyond the rename itself, three places in the diff carry follow-up corrections so the v2 release is self-consistent:

- `IntegrationTest.yml`: the gate's `${{ needs.test.result }}` reference was updated to `${{ needs.integration-test.result }}` after the matrix-job key rename. Without this, the gate would have computed `RESULT=` (empty) and fallen through to the failure case for every caller.
- `FormatCheckComment.yml`: the `check-name` input default was updated from `"Format Check"` to `"FormatCheck"` so callers that don't override the input pick up the new caller-side workflow name correctly.
- `README.md`: 21 `@v1` example references in `uses:` blocks updated to `@v2` (since `v2` is the new current major), and the stale `Format Check / Check Formatting` context reference updated to `FormatCheck / FormatCheck`.

No reusable-workflow input names changed. Callers' `with:` blocks need no edits beyond updating the `uses:` reference from `@v1` to `@v2` and updating their FormatCheckComment.yml workflow_run trigger string from `workflows: ["Format Check"]` to `workflows: ["FormatCheck"]`.

## Convention

- Workflow `name:` matches filename basename. Drops the older `Reusable X Workflow` decoration.
- Single-job workflows: job display name matches filename.
- Multi-job / matrix workflows: keep informative display names where they distinguish jobs (matrix legs, multiple TagBot registries).
- Job keys are kebab-case lowercase. Brand names (TagBot, CompatHelper) are treated as single words for the lowercase form (`tagbot`, `compathelper`) rather than being split on internal capitals.

## Rollout (separate PRs)

- Tag this release as `v2.0.0` and create the `v2` mutable tag once merged.
- Update `ITensorPkgSkeleton.jl` workflow templates to reference `@v2` and use the renamed caller-side names.
- Sweep across the standard repo set: per-repo PR carrying caller-side renames + `@v1` → `@v2` reference bump + the in-flight permissions blocks already in templates.
- Update branch-protection rulesets across the org to the new context strings.