### PR TITLE
Documentation.yml + LiterateCheck.yml: explicit Pkg.instantiate() for fail-fast

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -138,6 +138,13 @@ jobs:
             end
           end
           Pkg.develop(Pkg.PackageSpec(path=pwd()))
+          # Explicit instantiate so docs/Manifest.toml resolution failures
+          # (e.g. compat conflicts that would leave packages like Documenter
+          # missing from the depot) surface here rather than silently
+          # passing through to the docs/make.jl step, which then fails with
+          # a confusing "Package X is required but does not seem to be
+          # installed" error several minutes later.
+          Pkg.instantiate()
           retry(Pkg.build)(verbose=true)
           EOF
       - name: "Build and Deploy Documentation"

--- a/.github/workflows/LiterateCheck.yml
+++ b/.github/workflows/LiterateCheck.yml
@@ -56,6 +56,11 @@ jobs:
             end
           end
           Pkg.develop(Pkg.PackageSpec(path=pwd()))
+          # Explicit instantiate so docs/Manifest.toml resolution failures
+          # surface here (not deferred to the make_readme.jl step with a
+          # confusing "Package X is required but does not seem to be
+          # installed" error). Same rationale as Documentation.yml.
+          Pkg.instantiate()
           retry(Pkg.build)(verbose=true)
       - name: "Build README"
         run: julia --project=docs/ docs/make_readme.jl


### PR DESCRIPTION
## Summary

The setup-project step in two reusable workflows (`Documentation.yml`, `LiterateCheck.yml`) called `Pkg.develop(path=pwd())` and went straight to `retry(Pkg.build)` without forcing the `docs/Manifest.toml` to be instantiated. When `docs/Manifest` had a resolution problem (compat conflict, registry-version pin that no longer exists, etc.), `Pkg.develop` could leave packages like Documenter missing from the depot. `Pkg.build` then succeeded with whatever was installed, the step exited cleanly, and the build step several minutes later failed with the confusing message:

```
Package Documenter [e30172f5-...] is required but does not seem to be installed
```

— far from where the actual problem was.

Adding an explicit `Pkg.instantiate()` between `Pkg.develop` and `Pkg.build` forces full manifest resolution at the setup step. Resolution failures now error there, where the message points at the real cause, instead of being deferred.

Surfaced on `GradedArrays.jl#167` where the `docs/Project.toml` had a transient compat conflict — the contributor saw "Documenter does not seem to be installed" while the actual cause was several minutes upstream in the manifest resolution.

Survey of the other reusable workflows: `Tests.yml`, `CheckCompatBounds.yml`, and `IntegrationTest.yml` all already fail fast (via `julia-actions/julia-buildpkg@v1` or deliberate ResolverError-as-success handling). `CompatHelper.yml`, `Registrator.yml`, and `VersionCheck.yml` don't exercise this code path. `LiterateCheck.yml` was the only other offender.