### PR TITLE
Bump actions/checkout from v4/v5 to v6 across all reusables

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: "Setup Julia ${{ inputs.julia-version }}"
         uses: julia-actions/setup-julia@v3

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -78,7 +78,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: "Install apt packages"
         if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Check out PR head
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -42,7 +42,7 @@ jobs:
           HEAD_REF=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} --jq '.head.ref')
           echo "head_ref=$HEAD_REF" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.head_ref }}
           token: ${{ secrets.FORMATPULLREQUEST_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           name: integration-test-skip-${{ steps.skip_artifact.outputs.key }}
           path: ${{ steps.skip_artifact.outputs.path }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.gate.outputs.skip != 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/LiterateCheck.yml
+++ b/.github/workflows/LiterateCheck.yml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: "${{ inputs.julia-version }}"

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -73,7 +73,7 @@ jobs:
           delete-old-caches: false
 
       - name: Checkout package
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: package
           fetch-depth: 0
@@ -271,7 +271,7 @@ jobs:
 
       - name: Checkout local registry
         if: steps.meta.outputs.route == 'local'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "${{ inputs.localregistry }}"
           path: registry

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -118,7 +118,7 @@ jobs:
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: "Install apt packages"
         if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
         id: classify


### PR DESCRIPTION
## Summary

Dependabot has historically not proposed `actions/checkout` bumps for this repo despite v5 (Aug 2025) and v6 (Nov 2025, currently v6.0.2) both being available. Likely a side-effect of the 13-month stuck schedule that recovered earlier today — the catch-up tick processed several other actions but appears to have skipped `checkout`. Bumping manually to re-prime Dependabot's tracking from v6.

State before: 9 files pinned to v4, 1 file (FormatCheck.yml) at v5.
State after: all 10 files at v6.

## Release-note review

- v5.0.0 (Aug 2025): updates to Node.js 24 runtime; requires runner v2.327.1+. GitHub-hosted runners auto-update so no action needed. No API changes.
- v6.0.0 (Nov 2025): internal refactor to persist credentials to a separate file. No API changes affecting consumers.

Both are safe drop-in replacements.