### PR TITLE
Add CodeQL.yml reusable for path-aware Actions-language analysis

### DIFF
--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -11,10 +11,26 @@ name: "CodeQL"
 #
 # Caller wires this up via:
 #
+#   name: "CodeQL"
+#   on:
+#     pull_request:
+#       branches:
+#         - "main"
+#   permissions:
+#     contents: "read"
+#     security-events: "write"
+#     actions: "read"
 #   jobs:
 #     codeql:
 #       name: "CodeQL"
 #       uses: "ITensor/ITensorActions/.github/workflows/CodeQL.yml@v2"
+#
+# The caller-side `permissions:` block is mandatory. After the
+# org-default flip to read-only on 2026-05-04, the reusable's
+# job-level `permissions: { security-events: write }` request is
+# capped by the caller's workflow-level grant — without an explicit
+# `security-events: write` at the caller, CodeQL's SARIF upload
+# fails on every same-repo PR.
 #
 # Resulting check-run name reported to GitHub: `CodeQL / Analyze (actions)`.
 # That's the string the branch ruleset needs to require.

--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -1,0 +1,95 @@
+name: "CodeQL"
+
+# Reusable workflow that runs CodeQL Actions analysis on PRs that change
+# `.github/workflows/**`, reports success-without-running on PRs that don't,
+# and reports `skipped` on fork PRs that touch workflow files (so auto-merge
+# can't fire and a maintainer must consciously intervene).
+#
+# Replaces GitHub's CodeQL default-setup, which deliberately skips fork PRs
+# from external contributors as a security measure — leaving the required
+# `Analyze (actions)` check unreachable on those PRs without admin bypass.
+#
+# Caller wires this up via:
+#
+#   jobs:
+#     codeql:
+#       name: "CodeQL"
+#       uses: "ITensor/ITensorActions/.github/workflows/CodeQL.yml@v2"
+#
+# Resulting check-run name reported to GitHub: `CodeQL / Analyze (actions)`.
+# That's the string the branch ruleset needs to require.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      is_fork: ${{ steps.context.outputs.is_fork }}
+      changed: ${{ steps.changed.outputs.any }}
+    steps:
+      - name: "Determine fork status"
+        id: context
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$HEAD_REPO" ] || [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: "Detect workflow changes"
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Non-PR triggers (e.g. workflow_dispatch) leave both SHAs empty.
+          # Treat as "changed=true" so the analysis runs in those cases.
+          if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+            echo "any=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+               | grep -q '^\.github/workflows/'; then
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  analyze:
+    name: "Analyze (actions)"
+    needs: detect
+    # Skip when fork PR touches workflow files. Job-level `if: false`
+    # gives the check a `skipped` conclusion (distinct from `failure`),
+    # which fails required-check satisfaction and prevents auto-merge
+    # from firing. A maintainer must consciously bypass after reviewing
+    # the workflow diff (the realistic Trivy-attack scenario surface).
+    if: ${{ !(needs.detect.outputs.is_fork == 'true' && needs.detect.outputs.changed == 'true') }}
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ needs.detect.outputs.changed == 'true' }}
+        uses: actions/checkout@v6
+
+      - if: ${{ needs.detect.outputs.changed == 'true' }}
+        uses: github/codeql-action/init@v3
+        with:
+          languages: actions
+
+      - if: ${{ needs.detect.outputs.changed == 'true' }}
+        uses: github/codeql-action/analyze@v3
+
+      - if: ${{ needs.detect.outputs.changed != 'true' }}
+        run: echo "No workflow files changed; skipping CodeQL Actions analysis."

--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -1,39 +1,7 @@
 name: "CodeQL"
 
-# Reusable workflow that runs CodeQL Actions analysis on PRs that change
-# `.github/workflows/**`, reports success-without-running on PRs that don't,
-# and reports `skipped` on fork PRs that touch workflow files (so auto-merge
-# can't fire and a maintainer must consciously intervene).
-#
-# Replaces GitHub's CodeQL default-setup, which deliberately skips fork PRs
-# from external contributors as a security measure — leaving the required
-# `Analyze (actions)` check unreachable on those PRs without admin bypass.
-#
-# Caller wires this up via:
-#
-#   name: "CodeQL"
-#   on:
-#     pull_request:
-#       branches:
-#         - "main"
-#   permissions:
-#     contents: "read"
-#     security-events: "write"
-#     actions: "read"
-#   jobs:
-#     codeql:
-#       name: "CodeQL"
-#       uses: "ITensor/ITensorActions/.github/workflows/CodeQL.yml@v2"
-#
-# The caller-side `permissions:` block is mandatory. After the
-# org-default flip to read-only on 2026-05-04, the reusable's
-# job-level `permissions: { security-events: write }` request is
-# capped by the caller's workflow-level grant — without an explicit
-# `security-events: write` at the caller, CodeQL's SARIF upload
-# fails on every same-repo PR.
-#
-# Resulting check-run name reported to GitHub: `CodeQL / Analyze (actions)`.
-# That's the string the branch ruleset needs to require.
+# See the README's `## CodeQL` section for the caller-side template,
+# behavior table, and rationale.
 
 on:
   workflow_call:

--- a/README.md
+++ b/README.md
@@ -10,30 +10,30 @@ Callers should pin to a major-version tag rather than to `@main`:
 uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v2"
 ```
 
-Releases follow `vMAJOR.MINOR.PATCH` (e.g. `v1.0.0`, `v1.0.1`,
-`v1.1.0`). A mutable major-version tag (`v1`) is updated to point at
-the latest `v1.x.y` after each release, mirroring the convention
+Releases follow `vMAJOR.MINOR.PATCH` (e.g. `v2.0.0`, `v2.0.1`,
+`v2.1.0`). A mutable major-version tag (`v2`) is updated to point at
+the latest `v2.x.y` after each release, mirroring the convention
 used by `actions/checkout`, `julia-actions/setup-julia`, and similar
 third-party reusable actions. Callers should reference `@v2` for
-"latest in major version 1"; SHA-pinning to a specific `v1.x.y`
+"latest in major version 2"; SHA-pinning to a specific `v2.x.y`
 release is also supported when extra rigor is needed.
 
 SemVer release decision rule:
 
-- Patch (`v1.0.x`): bug fixes, docs-only improvements, or internal
+- Patch (`v2.0.x`): bug fixes, docs-only improvements, or internal
   hardening that does not change caller-facing workflow interfaces.
-- Minor (`v1.x.0`): backward-compatible new inputs, new reusable
+- Minor (`v2.x.0`): backward-compatible new inputs, new reusable
   workflows, or additive behavior.
-- Major (`v2.0.0`): breaking caller-facing changes (renamed/removed
+- Major (`v3.0.0`): breaking caller-facing changes (renamed/removed
   inputs, changed required secrets/permissions, incompatible behavior).
 
 Each released commit should be assigned exactly one of the three bump
-types above. Keep `v1.0.0`, `v1.1.0`, etc. immutable; move the mutable
-`v1` tag to the newest `v1.x.y` release.
+types above. Keep `v2.0.0`, `v2.1.0`, etc. immutable; move the mutable
+`v2` tag to the newest `v2.x.y` release.
 
 Docs-only PRs (for example README clarifications that do not change
 workflow behavior) do not require a SemVer release, do not require a
-new `v1.x.y` tag, and should not move `v1`.
+new `v2.x.y` tag, and should not move `v2`.
 
 Breaking changes (e.g. a renamed input) bump the major version. The
 old major tag stays in place so existing callers keep working until
@@ -717,6 +717,73 @@ Exit code `0` means every workspace compat entry is resolved to its maximum
 allowed version; exit code `1` means at least one entry is outdated, with a
 per-entry message identifying the package, resolved version, and allowed
 ceiling.
+
+## CodeQL
+
+The `CodeQL` workflow runs the GitHub CodeQL Actions-language analysis
+on PRs. It replaces GitHub's
+[default-setup CodeQL](https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning)
+with a path-aware advanced-setup reusable that runs only when relevant
+and reports a status check that's reachable for fork PRs from external
+contributors (which default-setup deliberately skips).
+
+### Caller
+
+```yaml
+name: "CodeQL"
+on:
+  pull_request:
+    branches:
+      - "main"
+permissions:
+  contents: "read"
+  security-events: "write"
+  actions: "read"
+jobs:
+  codeql:
+    name: "CodeQL"
+    uses: "ITensor/ITensorActions/.github/workflows/CodeQL.yml@v2"
+```
+
+The caller-side `permissions:` block is mandatory. After the
+org-default flip to read-only `GITHUB_TOKEN`, the reusable's job-level
+`security-events: write` request is capped by the caller's
+workflow-level grant — without an explicit `security-events: write` at
+the caller, CodeQL's SARIF upload fails on every same-repo PR.
+
+The resulting check-run name reported to GitHub is
+`CodeQL / Analyze (actions)`. That's the string a branch ruleset
+should require.
+
+### Behavior
+
+| PR source | Touches `.github/workflows/**`? | `analyze` job | Conclusion |
+|---|---|---|---|
+| Same-repo | No | runs (no-op steps) | `success` |
+| Same-repo | Yes | runs CodeQL | `success` / `failure` |
+| Fork | No | runs (no-op steps) | `success` |
+| Fork | Yes | **skipped** (job-level `if: false`) | **`skipped`** → required check unsatisfied → auto-merge blocked, admin bypass needed |
+
+The `skipped` conclusion (rather than `failure`) on the
+fork-PR-touches-workflows row is intentional: it semantically reads as
+"couldn't run, manual review needed", not "ran and broke", and is the
+right signal for fork PRs whose workflow diffs need human scrutiny
+anyway. The skip blocks auto-merge and forces a maintainer to
+consciously bypass after reviewing the diff (the realistic
+Trivy-attack scenario surface).
+
+### Why advanced setup instead of default-setup
+
+GitHub's CodeQL default-setup skips fork PRs from external
+contributors as a security measure. When the resulting `Analyze
+(actions)` check is required by branch protection, the check never
+reports on those PRs and they can never merge without admin bypass.
+
+External contributors realistically don't change `.github/workflows/`
+— that's infrastructure, not contribution. So scoping the CodeQL run
+to PRs that actually touch workflow files keeps the security signal
+where it matters and removes the merge-blocking on the realistic
+external-contributor case.
 
 ## Registrator
 


### PR DESCRIPTION
## Summary

New reusable workflow `CodeQL.yml` that runs CodeQL Actions analysis only when relevant and reports a status check that's reachable for fork PRs. Replaces consumer-side CodeQL default-setup, which deliberately skips fork PRs from external contributors and leaves the required `Analyze (actions)` check unreachable on those PRs.

See the new `## CodeQL` section in the README for the caller template, behavior table, and rationale. Followup work (caller template in ITensorPkgSkeleton, ecosystem sweep, ruleset update) is tracked in `Projects/Ecosystem/codeql_advanced_setup/` in ITensorDevelopmentPlans.

While here: bumped the Versioning section's `v1` examples to `v2` to match the current major.