### PR TITLE
Add explicit job name fields for cosmetic UI consistency

### DIFF
--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   detect:
+    name: "Detect"
     runs-on: ubuntu-latest
     outputs:
       is_fork: ${{ steps.context.outputs.is_fork }}

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -23,11 +23,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Check if Julia is already available in the PATH
+      - name: "Check if Julia is already available in the PATH"
         id: julia_in_path
         run: which julia
         continue-on-error: true
-      - name: Install Julia, but only if it is not already available in the PATH
+      - name: "Install Julia, but only if it is not already available in the PATH"
         uses: julia-actions/setup-julia@v3
         with:
           version: "${{ inputs.julia-version }}"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           printf '%s\n' "$EXTRA_ENV" >> "$GITHUB_ENV"
 
-      - name: Setup project
+      - name: "Setup project"
         shell: "bash"
         env:
           LOCALREGISTRY: ${{ inputs.localregistry }}
@@ -147,7 +147,7 @@ jobs:
           Pkg.instantiate()
           retry(Pkg.build)(verbose=true)
           EOF
-      - name: "Build and Deploy Documentation"
+      - name: "Build and deploy documentation"
         env:
           GITHUB_TOKEN: ${{ inputs.github-token || secrets.GITHUB_TOKEN }}
           JULIA_DEBUG: ${{ inputs.debug-documenter && 'Documenter' || '' }}
@@ -161,7 +161,7 @@ jobs:
         with:
           directories: "${{ inputs.coverage-directories }}"
 
-      - name: "Report Coverage with Codecov"
+      - name: "Report coverage with Codecov"
         uses: codecov/codecov-action@v6
         if: "${{ inputs.coverage }}"
         with:

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -50,14 +50,14 @@ jobs:
       contents: read
 
     steps:
-      - name: Check out PR head
+      - name: "Check out PR head"
         uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Setup Julia
+      - name: "Setup Julia"
         uses: julia-actions/setup-julia@v3
         with:
           version: "${{ inputs.julia-version }}"
@@ -65,7 +65,7 @@ jobs:
 
       - uses: julia-actions/cache@v2
 
-      - name: Install ITensorFormatter
+      - name: "Install ITensorFormatter"
         run: |
           julia -e '
             using Pkg
@@ -75,7 +75,7 @@ jobs:
           '
           echo "$HOME/.julia/bin" >> $GITHUB_PATH
 
-      - name: Run ITensorFormatter
+      - name: "Run ITensorFormatter"
         id: format
         env:
           DIRECTORY: ${{ inputs.directory }}
@@ -99,7 +99,7 @@ jobs:
             echo "exit_code=0" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Save metadata for comment workflow
+      - name: "Save metadata for comment workflow"
         if: ${{ always() }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -112,17 +112,17 @@ jobs:
             echo "exit_code=${EXIT_CODE:-2}"
           } > metadata.txt
 
-      - name: Upload artifact for comment workflow
+      - name: "Upload artifact for comment workflow"
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: format-check
+          name: "format-check"
           path: |
             metadata.txt
             diff.patch
           if-no-files-found: ignore
 
-      - name: Propagate exit code
+      - name: "Propagate exit code"
         run: |
           # exit 0 -> already formatted; exit 1 -> formatting needed;
           # exit 2 -> formatter itself errored. The check status reflects

--- a/.github/workflows/FormatCheckComment.yml
+++ b/.github/workflows/FormatCheckComment.yml
@@ -32,16 +32,16 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - name: Download FormatCheck artifact
+      - name: "Download FormatCheck artifact"
         id: download
         uses: actions/download-artifact@v4
         with:
-          name: format-check
+          name: "format-check"
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
         continue-on-error: true
 
-      - name: Read metadata
+      - name: "Read metadata"
         if: steps.download.outcome == 'success'
         id: meta
         run: |
@@ -61,7 +61,7 @@ jobs:
           echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      - name: Find existing format-check comment
+      - name: "Find existing format-check comment"
         if: steps.meta.outputs.skip == 'false'
         uses: peter-evans/find-comment@v3
         id: find-comment
@@ -70,7 +70,7 @@ jobs:
           issue-number: ${{ steps.meta.outputs.pr_number }}
           body-includes: "<!-- format-check-summary -->"
 
-      - name: Compose suggestion-comment body
+      - name: "Compose suggestion-comment body"
         if: steps.meta.outputs.skip == 'false' && steps.meta.outputs.exit_code == '1'
         run: |
           {
@@ -90,7 +90,7 @@ jobs:
             echo "</details>"
           } > comment-body.md
 
-      - name: Post or update suggestion comment
+      - name: "Post or update suggestion comment"
         if: steps.meta.outputs.skip == 'false' && steps.meta.outputs.exit_code == '1'
         uses: peter-evans/create-or-update-comment@v5
         with:
@@ -100,7 +100,7 @@ jobs:
           body-path: comment-body.md
           edit-mode: replace
 
-      - name: Clear stale comment when formatting now passes
+      - name: "Clear stale comment when formatting now passes"
         if: steps.meta.outputs.skip == 'false' && steps.meta.outputs.exit_code == '0' && steps.find-comment.outputs.comment-id
         uses: peter-evans/create-or-update-comment@v5
         with:

--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -33,7 +33,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Get PR branch
+      - name: "Get PR branch"
         if: github.event_name == 'issue_comment'
         id: pr
         env:
@@ -55,7 +55,7 @@ jobs:
 
       - uses: julia-actions/cache@v2
 
-      - name: Install ITensorFormatter
+      - name: "Install ITensorFormatter"
         run: |
           julia -e '
             using Pkg
@@ -65,14 +65,14 @@ jobs:
           '
           echo "$HOME/.julia/bin" >> $GITHUB_PATH
 
-      - name: Run ITensorFormatter
+      - name: "Run ITensorFormatter"
         env:
           DIRECTORY: ${{ inputs.directory }}
         run: |
           itpkgfmt "$DIRECTORY"
         continue-on-error: true
 
-      - name: Detect formatting changes
+      - name: "Detect formatting changes"
         id: changes
         shell: bash
         run: |
@@ -88,7 +88,7 @@ jobs:
       # attribution all match the identity the token authenticates as.
       # Falls back to github-actions[bot] when FORMATPULLREQUEST_PAT is
       # unset (forks, etc.).
-      - name: Detect token owner
+      - name: "Detect token owner"
         id: token-owner
         env:
           GH_TOKEN: ${{ secrets.FORMATPULLREQUEST_PAT || secrets.GITHUB_TOKEN }}
@@ -108,7 +108,7 @@ jobs:
           echo "email=$email" >> "$GITHUB_OUTPUT"
 
       # issue_comment mode: commit directly to the PR branch
-      - name: Commit and push changes
+      - name: "Commit and push changes"
         if: github.event_name == 'issue_comment' && steps.changes.outputs.changes == 'true'
         env:
           GIT_NAME: ${{ steps.token-owner.outputs.name }}
@@ -121,7 +121,7 @@ jobs:
           git push
 
       # issue_comment mode: react to the triggering comment
-      - name: React to comment
+      - name: "React to comment"
         if: github.event_name == 'issue_comment'
         uses: peter-evans/create-or-update-comment@v5
         with:
@@ -130,7 +130,7 @@ jobs:
           reactions: '+1'
 
       # schedule/dispatch mode: bump version and open a new PR
-      - name: Bump patch version
+      - name: "Bump patch version"
         if: github.event_name != 'issue_comment' && steps.changes.outputs.changes == 'true'
         shell: julia --color=yes {0}
         run: |
@@ -140,12 +140,12 @@ jobs:
           project.version = Base.nextpatch(project.version)
           Pkg.Types.write_project(project, project_file)
 
-      - name: Stage changes (including new files)
+      - name: "Stage changes (including new files)"
         if: github.event_name != 'issue_comment' && steps.changes.outputs.changes == 'true'
         shell: bash
         run: git add -A
 
-      - name: Create Pull Request
+      - name: "Create pull request"
         if: github.event_name != 'issue_comment' && steps.changes.outputs.changes == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v8
@@ -158,7 +158,7 @@ jobs:
           author: "${{ steps.token-owner.outputs.name }} <${{ steps.token-owner.outputs.email }}>"
           committer: "${{ steps.token-owner.outputs.name }} <${{ steps.token-owner.outputs.email }}>"
 
-      - name: Check outputs
+      - name: "Check outputs"
         if: github.event_name != 'issue_comment'
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   integration-test:
-    name: ${{ matrix.pkg }}
+    name: "${{ matrix.pkg }}"
     # Skip the matrix-driven leg entirely when `pkgs` is empty. Without this
     # guard, GitHub Actions reports an empty-matrix job as `failure`, which
     # propagates to the run's overall conclusion even though the aggregating
@@ -106,7 +106,7 @@ jobs:
         if: steps.gate.outputs.skip == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: integration-test-skip-${{ steps.skip_artifact.outputs.key }}
+          name: "integration-test-skip-${{ steps.skip_artifact.outputs.key }}"
           path: ${{ steps.skip_artifact.outputs.path }}
       - uses: actions/checkout@v6
         if: steps.gate.outputs.skip != 'true'
@@ -128,7 +128,7 @@ jobs:
               git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
             fi
           fi
-      - name: Run the downstream tests
+      - name: "Run the downstream tests"
         if: steps.gate.outputs.skip != 'true'
         shell: julia --color=yes --project=downstream {0}
         env:

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   get-pr-comment:
-    name: "Get PR comment"
+    name: "Get PR Comment"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -30,7 +30,7 @@ jobs:
       pkgs: ${{ steps.extract.outputs.pkgs }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
     steps:
-      - name: Extract command arguments
+      - name: "Extract command arguments"
         id: extract
         env:
           COMMENT: ${{ github.event.comment.body }}
@@ -45,7 +45,7 @@ jobs:
           # workflow's `pkgs` input. `jq` handles any escaping for us.
           PKGS=$(jq -nc --arg pkg "$PKG" '[$pkg]')
           echo "pkgs=$PKGS" >> "$GITHUB_OUTPUT"
-      - name: Resolve PR head SHA
+      - name: "Resolve PR head SHA"
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
@@ -56,7 +56,7 @@ jobs:
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
   run-tests:
-    name: "Run tests"
+    name: "Run Tests"
     needs: get-pr-comment
     uses: ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main
     with:
@@ -74,7 +74,7 @@ jobs:
       checks: write
       pull-requests: write
     steps:
-      - name: React to triggering comment
+      - name: "React to triggering comment"
         uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.INTEGRATIONTEST_PAT || github.token }}
@@ -85,7 +85,7 @@ jobs:
       # successful `/integrationtest` clear the IntegrationTest gate on
       # fork PRs whose private-only matrix would otherwise leave that
       # gate failing.
-      - name: Post passing IntegrationTest check
+      - name: "Post passing IntegrationTest check"
         if: ${{ needs.run-tests.result == 'success' }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   get-pr-comment:
+    name: "Get PR comment"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,6 +56,7 @@ jobs:
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
   run-tests:
+    name: "Run tests"
     needs: get-pr-comment
     uses: ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main
     with:
@@ -64,6 +66,7 @@ jobs:
     secrets: inherit
 
   report:
+    name: "Report"
     needs: [get-pr-comment, run-tests]
     if: ${{ always() && needs.get-pr-comment.result == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/LiterateCheck.yml
+++ b/.github/workflows/LiterateCheck.yml
@@ -1,4 +1,4 @@
-name: "Reusable Readme Generation Checking Workflow"
+name: "LiterateCheck"
 
 on:
   workflow_call:
@@ -36,7 +36,7 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: "${{ inputs.julia-version }}"
-      - name: Setup project
+      - name: "Setup project"
         shell: julia --project=docs --color=yes {0}
         env:
           LOCALREGISTRY: ${{ inputs.localregistry }}
@@ -64,7 +64,7 @@ jobs:
           retry(Pkg.build)(verbose=true)
       - name: "Build README"
         run: julia --project=docs/ docs/make_readme.jl
-      - name: Check if docs need to be updated
+      - name: "Check if docs need to be updated"
         id: check-literate
         run: |
           MODIFIED_FILES="$(git diff --name-only README.md)"

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -48,7 +48,7 @@ jobs:
       TARGET_SHA: ${{ (github.event.pull_request && github.event.pull_request.merged && github.event.pull_request.merge_commit_sha) || (github.event.pull_request && github.event.pull_request.head.sha) || github.sha }}
 
     steps:
-      - name: Get target SHA from comment
+      - name: "Get target SHA from comment"
         if: github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -72,14 +72,14 @@ jobs:
         with:
           delete-old-caches: false
 
-      - name: Checkout package
+      - name: "Checkout package"
         uses: actions/checkout@v6
         with:
           path: package
           fetch-depth: 0
           ref: ${{ env.TARGET_SHA }}
 
-      - name: Decide route (General vs local) + validate version bump
+      - name: "Decide route (General vs local) + validate version bump"
         id: meta
         env:
           OLD_REF: ${{ github.event.before }}
@@ -200,7 +200,7 @@ jobs:
               end
           end
 
-      - name: Summary (skipped)
+      - name: "Summary (skipped)"
         if: steps.meta.outputs.route == 'none'
         run: |
           {
@@ -210,7 +210,7 @@ jobs:
 
       # ---- General registry path ----
 
-      - name: Compose Registrator commit comment
+      - name: "Compose Registrator commit comment"
         if: steps.meta.outputs.route == 'general'
         shell: bash
         env:
@@ -227,7 +227,7 @@ jobs:
             fi
           } > registrator-comment.md
 
-      - name: Trigger Registrator (General)
+      - name: "Trigger Registrator (General)"
         if: steps.meta.outputs.route == 'general'
         id: cc
         uses: peter-evans/commit-comment@v4
@@ -236,7 +236,7 @@ jobs:
           sha: ${{ env.TARGET_SHA }}
           body-path: registrator-comment.md
 
-      - name: Summary (General)
+      - name: "Summary (General)"
         if: steps.meta.outputs.route == 'general'
         run: |
           {
@@ -252,13 +252,13 @@ jobs:
 
       # ---- Local registry path ----
 
-      - name: Validate local registry input
+      - name: "Validate local registry input"
         if: steps.meta.outputs.route == 'local' && inputs.localregistry == ''
         run: |
           echo "inputs.localregistry is required when the package is not in General." >&2
           exit 1
 
-      - name: Validate REGISTRATOR_PAT (local registry)
+      - name: "Validate REGISTRATOR_PAT (local registry)"
         if: steps.meta.outputs.route == 'local'
         env:
           REGISTRATOR_PAT: ${{ secrets.REGISTRATOR_PAT }}
@@ -269,7 +269,7 @@ jobs:
             exit 1
           fi
 
-      - name: Checkout local registry
+      - name: "Checkout local registry"
         if: steps.meta.outputs.route == 'local'
         uses: actions/checkout@v6
         with:
@@ -281,7 +281,7 @@ jobs:
       # both match the authenticating identity. Without this, peter-evans
       # below defaults the author to the workflow-trigger commit author and
       # the committer to github-actions[bot].
-      - name: Detect token owner
+      - name: "Detect token owner"
         if: steps.meta.outputs.route == 'local'
         id: token-owner
         env:
@@ -301,7 +301,7 @@ jobs:
           echo "name=$name" >> "$GITHUB_OUTPUT"
           echo "email=$email" >> "$GITHUB_OUTPUT"
 
-      - name: Compose PR metadata (local registry)
+      - name: "Compose PR metadata (local registry)"
         if: steps.meta.outputs.route == 'local'
         id: local_pr
         env:
@@ -334,7 +334,7 @@ jobs:
               println(io, "EOF")
           end
 
-      - name: Update local registry
+      - name: "Update local registry"
         if: steps.meta.outputs.route == 'local'
         shell: julia --color=yes {0}
         run: |
@@ -346,7 +346,7 @@ jobs:
           using LocalRegistry
           register("./package"; registry="./registry", commit=false, push=false)
 
-      - name: Create PR to registry
+      - name: "Create PR to registry"
         if: steps.meta.outputs.route == 'local'
         id: cpr
         uses: peter-evans/create-pull-request@v8
@@ -360,7 +360,7 @@ jobs:
           author: "${{ steps.token-owner.outputs.name }} <${{ steps.token-owner.outputs.email }}>"
           committer: "${{ steps.token-owner.outputs.name }} <${{ steps.token-owner.outputs.email }}>"
 
-      - name: Summary (Local registry)
+      - name: "Summary (local registry)"
         if: steps.meta.outputs.route == 'local'
         run: |
           {
@@ -376,7 +376,7 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: React to comment
+      - name: "React to comment"
         if: github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ secrets.REGISTRATOR_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           token: "${{ secrets.TAGBOT_PAT || github.token }}"
   tagbot-general-subdirs:
-    name: "TagBot (General subdirs)"
+    name: "TagBot (General Subdirs)"
     if: "${{ inputs.subdirs != '[]' }}"
     runs-on: "ubuntu-latest"
     permissions:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -185,7 +185,7 @@ jobs:
         with:
           directories: "${{ inputs.coverage-directories }}"
 
-      - name: "Report Coverage with Codecov"
+      - name: "Report coverage with Codecov"
         uses: codecov/codecov-action@v6
         if: "${{ inputs.coverage }}"
         with:


### PR DESCRIPTION
## Summary
Cosmetic-only normalization of all `name:` fields across reusable workflows.

- Add explicit `name:` to four jobs that lacked it (defaulted to lowercase YAML keys): `Detect` in `CodeQL.yml`, `Get PR Comment` / `Run Tests` / `Report` in `IntegrationTestRequest.yml`.
- Quote every `name:` value (workflow, job, step, artifact-name) for a single uniform style.
- Apply the existing Title-Case-with-spaces convention (matching `Literate Check`, `Analyze (actions)`) to all multi-word job display names.
- Sentence case three outlier step names that drifted into title case: `Build and deploy documentation`, `Report coverage with Codecov` (x2), `Create pull request`.
- Fix `LiterateCheck` workflow display name to match its filename (was `Reusable Readme Generation Checking Workflow`).
- `TagBot (General Subdirs)`: capitalize `Subdirs` for consistency with `(ITensorRegistry)` / `(General)`.
- `Summary (local registry)`: lowercase to match this file's other `(local registry)` clarifiers.

No behavior change. Required check identifiers used downstream are unaffected.