### PR TITLE
Add subdir-aware inputs to standard reusables (v2.2.0)

### DIFF
--- a/.github/actions/classify-pr/action.yml
+++ b/.github/actions/classify-pr/action.yml
@@ -1,8 +1,17 @@
 name: "Classify PR substance"
 description: "Determines whether a PR touches substantive files or only CI/config (workflow-only) files. Outputs substantive=true|false."
+inputs:
+  subdir:
+    description: "Positive scope: when set, a file is substantive iff it lies under `<subdir>/`. Mutually exclusive with `exclude-subdirs`."
+    required: false
+    default: ""
+  exclude-subdirs:
+    description: "Negative scope at root: newline-separated list of sibling subdirectories to exclude. When set (and `subdir` empty), a file is substantive iff it lies outside `.github/**`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`, AND outside any listed `<sibling>/`."
+    required: false
+    default: ""
 outputs:
   substantive:
-    description: "true if the PR touches substantive files; false if all changes are confined to .github/**, .pre-commit-config.yaml, .gitignore, or LICENSE."
+    description: "true if the PR touches substantive files; false otherwise."
     value: ${{ steps.classify.outputs.substantive }}
 runs:
   using: "composite"
@@ -13,8 +22,14 @@ runs:
         GH_TOKEN: ${{ github.token }}
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        SUBDIR: ${{ inputs.subdir }}
+        EXCLUDE_SUBDIRS: ${{ inputs.exclude-subdirs }}
       run: |
         set -euo pipefail
+        if [ -n "$SUBDIR" ] && [ -n "$EXCLUDE_SUBDIRS" ]; then
+          echo "::error::classify-pr: 'subdir' and 'exclude-subdirs' are mutually exclusive."
+          exit 1
+        fi
         if [ -z "${PR_NUMBER:-}" ]; then
           echo "Not a pull_request event; defaulting to substantive=true."
           echo "substantive=true" >> "$GITHUB_OUTPUT"
@@ -29,11 +44,39 @@ runs:
         echo "Changed files:"
         printf '  %s\n' $files
         substantive=false
-        while IFS= read -r file; do
-          case "$file" in
-            .github/*|.pre-commit-config.yaml|.gitignore|LICENSE) ;;
-            *) substantive=true; break ;;
-          esac
-        done <<< "$files"
+        if [ -n "$SUBDIR" ]; then
+          echo "Positive scope: ${SUBDIR}/"
+          while IFS= read -r file; do
+            case "$file" in
+              "$SUBDIR"/*) substantive=true; break ;;
+            esac
+          done <<< "$files"
+        else
+          # Build sibling-exclusion list (one prefix per non-empty line).
+          siblings=()
+          if [ -n "$EXCLUDE_SUBDIRS" ]; then
+            while IFS= read -r s; do
+              [ -z "$s" ] && continue
+              siblings+=("$s")
+            done <<< "$EXCLUDE_SUBDIRS"
+            echo "Root scope, excluding siblings: ${siblings[*]}"
+          fi
+          while IFS= read -r file; do
+            # Always-ignored metadata at root.
+            case "$file" in
+              .github/*|.pre-commit-config.yaml|.gitignore|LICENSE) continue ;;
+            esac
+            # Sibling-subdir exclusion (only when EXCLUDE_SUBDIRS set).
+            in_sibling=false
+            for sib in "${siblings[@]}"; do
+              case "$file" in
+                "$sib"/*) in_sibling=true; break ;;
+              esac
+            done
+            $in_sibling && continue
+            substantive=true
+            break
+          done <<< "$files"
+        fi
         echo "substantive=${substantive}"
         echo "substantive=${substantive}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/classify-pr/action.yml
+++ b/.github/actions/classify-pr/action.yml
@@ -1,12 +1,12 @@
 name: "Classify PR substance"
-description: "Determines whether a PR touches substantive files or only CI/config (workflow-only) files. Outputs substantive=true|false."
+description: "Reports whether a PR makes substantive changes — anything beyond CI/config metadata files (`.github/**`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`). Outputs substantive=true|false."
 inputs:
   subdir:
-    description: "Positive scope: when set, a file is substantive iff it lies under `<subdir>/`. Mutually exclusive with `exclude-subdirs`."
+    description: "Restrict the check to changes inside this subdirectory. Files outside `<subdir>/` don't count, and within `<subdir>/` the same metadata files that don't count at the repo root (`.github/`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`) also don't count. Use this for a workflow that's scoped to one in-tree subpackage. Mutually exclusive with `exclude-subdirs`."
     required: false
     default: ""
   exclude-subdirs:
-    description: "Negative scope at root: newline-separated list of sibling subdirectories to exclude. When set (and `subdir` empty), a file is substantive iff it lies outside `.github/**`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`, AND outside any listed `<sibling>/`."
+    description: "Newline-separated list of sibling subdirectories whose changes don't count. Use this for a root-package workflow in a multi-package repo so that PRs confined to a sibling subpackage are reported non-substantive. The repo-root metadata files (`.github/`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`) also don't count, as usual."
     required: false
     default: ""
 outputs:
@@ -45,11 +45,21 @@ runs:
         printf '  %s\n' $files
         substantive=false
         if [ -n "$SUBDIR" ]; then
-          echo "Positive scope: ${SUBDIR}/"
+          echo "Positive scope: ${SUBDIR}/ (with the usual metadata-file exclusions applied inside)"
           while IFS= read -r file; do
+            # Ignore files outside the scoped subdirectory.
             case "$file" in
-              "$SUBDIR"/*) substantive=true; break ;;
+              "$SUBDIR"/*) ;;
+              *) continue ;;
             esac
+            # Within the subdirectory, apply the same metadata-file
+            # exclusions as at the repo root.
+            rel="${file#"$SUBDIR"/}"
+            case "$rel" in
+              .github/*|.pre-commit-config.yaml|.gitignore|LICENSE) continue ;;
+            esac
+            substantive=true
+            break
           done <<< "$files"
         else
           # Build sibling-exclusion list (one prefix per non-empty line).

--- a/.github/actions/classify-pr/action.yml
+++ b/.github/actions/classify-pr/action.yml
@@ -1,18 +1,20 @@
-name: "Classify PR substance"
-description: "Reports whether a PR makes substantive changes — anything beyond CI/config metadata files (`.github/**`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`). Outputs substantive=true|false."
+name: "Classify PR scope"
+description: "Reports whether a PR has changes that should trigger this caller's work, given a path scope. A file 'triggers' iff it matches the caller's scope and is not in the exclude list. Outputs triggers=true|false."
 inputs:
-  subdir:
-    description: "Restrict the check to changes inside this subdirectory. Files outside `<subdir>/` don't count, and within `<subdir>/` the same metadata files that don't count at the repo root (`.github/`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`) also don't count. Use this for a workflow that's scoped to one in-tree subpackage. Mutually exclusive with `exclude-subdirs`."
+  paths:
+    description: "Newline-separated list of path prefixes / files defining positive scope. A file triggers iff it equals one of these paths or is inside one (i.e., starts with `<path>/`). Empty means everything is in scope. Mutually exclusive with `exclude-paths`."
     required: false
     default: ""
-  exclude-subdirs:
-    description: "Newline-separated list of sibling subdirectories whose changes don't count. Use this for a root-package workflow in a multi-package repo so that PRs confined to a sibling subpackage are reported non-substantive. The repo-root metadata files (`.github/`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`) also don't count, as usual."
+  exclude-paths:
+    description: "Newline-separated list of path prefixes / files defining negative scope. A file does NOT trigger if it equals one of these or is inside one. Default ignores `.gitignore` and `.pre-commit-config.yaml`. Override entirely (e.g. include the package's sibling subpackage and re-list defaults if you want them kept)."
     required: false
-    default: ""
+    default: |
+      .gitignore
+      .pre-commit-config.yaml
 outputs:
-  substantive:
-    description: "true if the PR touches substantive files; false otherwise."
-    value: ${{ steps.classify.outputs.substantive }}
+  triggers:
+    description: "true if the PR has at least one changed file that matches the configured scope; false otherwise."
+    value: ${{ steps.classify.outputs.triggers }}
 runs:
   using: "composite"
   steps:
@@ -22,71 +24,68 @@ runs:
         GH_TOKEN: ${{ github.token }}
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
-        SUBDIR: ${{ inputs.subdir }}
-        EXCLUDE_SUBDIRS: ${{ inputs.exclude-subdirs }}
+        PATHS: ${{ inputs.paths }}
+        EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
       run: |
         set -euo pipefail
-        if [ -n "$SUBDIR" ] && [ -n "$EXCLUDE_SUBDIRS" ]; then
-          echo "::error::classify-pr: 'subdir' and 'exclude-subdirs' are mutually exclusive."
-          exit 1
+        if [ -n "$PATHS" ] && [ -n "$EXCLUDE_PATHS" ]; then
+          # If paths is set, exclude-paths is ignored (caller is using positive scope).
+          # Surface a warning rather than failing so the user notices.
+          echo "::warning::classify-pr: 'paths' and 'exclude-paths' are mutually exclusive; using 'paths'."
+          EXCLUDE_PATHS=""
         fi
         if [ -z "${PR_NUMBER:-}" ]; then
-          echo "Not a pull_request event; defaulting to substantive=true."
-          echo "substantive=true" >> "$GITHUB_OUTPUT"
+          echo "Not a pull_request event; defaulting to triggers=true."
+          echo "triggers=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi
         files=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
         if [ -z "$files" ]; then
-          echo "No files reported for PR #${PR_NUMBER}; defaulting to substantive=true."
-          echo "substantive=true" >> "$GITHUB_OUTPUT"
+          echo "No files reported for PR #${PR_NUMBER}; defaulting to triggers=true."
+          echo "triggers=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi
         echo "Changed files:"
         printf '  %s\n' $files
-        substantive=false
-        if [ -n "$SUBDIR" ]; then
-          echo "Positive scope: ${SUBDIR}/ (with the usual metadata-file exclusions applied inside)"
-          while IFS= read -r file; do
-            # Ignore files outside the scoped subdirectory.
-            case "$file" in
-              "$SUBDIR"/*) ;;
-              *) continue ;;
-            esac
-            # Within the subdirectory, apply the same metadata-file
-            # exclusions as at the repo root.
-            rel="${file#"$SUBDIR"/}"
-            case "$rel" in
-              .github/*|.pre-commit-config.yaml|.gitignore|LICENSE) continue ;;
-            esac
-            substantive=true
-            break
-          done <<< "$files"
+
+        # Helper: check if a file matches any entry in a newline-separated list.
+        # An entry matches iff the file equals the entry, or the file starts with `<entry>/`.
+        matches_list() {
+          local file=$1
+          local list=$2
+          while IFS= read -r entry; do
+            [ -z "$entry" ] && continue
+            if [ "$file" = "$entry" ] || [[ "$file" == "$entry"/* ]]; then
+              return 0
+            fi
+          done <<< "$list"
+          return 1
+        }
+
+        if [ -n "$PATHS" ]; then
+          echo "Positive scope: any file matching one of the paths."
+          printf '  %s\n' $PATHS
         else
-          # Build sibling-exclusion list (one prefix per non-empty line).
-          siblings=()
-          if [ -n "$EXCLUDE_SUBDIRS" ]; then
-            while IFS= read -r s; do
-              [ -z "$s" ] && continue
-              siblings+=("$s")
-            done <<< "$EXCLUDE_SUBDIRS"
-            echo "Root scope, excluding siblings: ${siblings[*]}"
-          fi
-          while IFS= read -r file; do
-            # Always-ignored metadata at root.
-            case "$file" in
-              .github/*|.pre-commit-config.yaml|.gitignore|LICENSE) continue ;;
-            esac
-            # Sibling-subdir exclusion (only when EXCLUDE_SUBDIRS set).
-            in_sibling=false
-            for sib in "${siblings[@]}"; do
-              case "$file" in
-                "$sib"/*) in_sibling=true; break ;;
-              esac
-            done
-            $in_sibling && continue
-            substantive=true
-            break
-          done <<< "$files"
+          echo "Default scope: any file outside the exclude list."
+          printf '  exclude: %s\n' $EXCLUDE_PATHS
         fi
-        echo "substantive=${substantive}"
-        echo "substantive=${substantive}" >> "$GITHUB_OUTPUT"
+
+        triggers=false
+        while IFS= read -r file; do
+          if [ -n "$PATHS" ]; then
+            # Positive scope: file triggers iff it matches one of the listed paths.
+            if matches_list "$file" "$PATHS"; then
+              triggers=true
+              break
+            fi
+          else
+            # Negative scope: file triggers iff it is NOT in the exclude list.
+            if ! matches_list "$file" "$EXCLUDE_PATHS"; then
+              triggers=true
+              break
+            fi
+          fi
+        done <<< "$files"
+
+        echo "triggers=${triggers}"
+        echo "triggers=${triggers}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/classify-pr/action.yml
+++ b/.github/actions/classify-pr/action.yml
@@ -28,6 +28,20 @@ runs:
         EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
       run: |
         set -euo pipefail
+        # Normalize: treat whitespace-only inputs as empty. This matters
+        # because reusables that auto-append a value (e.g. `subdir`) into
+        # `paths` produce a list of all-empty lines when the appended
+        # value is also empty — bash's [ -n ] would otherwise misread that
+        # as "positive scope set", flipping the action into the wrong mode.
+        has_content() {
+          while IFS= read -r line; do
+            [ -n "$line" ] && return 0
+          done <<< "$1"
+          return 1
+        }
+        has_content "$PATHS" || PATHS=""
+        has_content "$EXCLUDE_PATHS" || EXCLUDE_PATHS=""
+
         if [ -n "$PATHS" ] && [ -n "$EXCLUDE_PATHS" ]; then
           # If paths is set, exclude-paths is ignored (caller is using positive scope).
           # Surface a warning rather than failing so the user notices.

--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -9,8 +9,13 @@ on:
         required: false
         type: string
       project:
-        description: "The value is passed to Julia's `--project` flag during buildpkg."
+        description: "Deprecated alias for `subdir`. Value passed to Julia's `--project` flag during buildpkg. When `subdir` is set, it takes precedence."
         default: '@.'
+        required: false
+        type: string
+      subdir:
+        description: "Subdirectory containing the package's Project.toml. When set, both buildpkg's `--project` and the check-compat-bounds workspace-root resolve to `<subdir>`. Empty (default) uses repo root."
+        default: ""
         required: false
         type: string
       cache:
@@ -74,10 +79,10 @@ jobs:
         if: "${{ inputs.buildpkg }}"
         with:
           localregistry: "${{ inputs.localregistry }}"
-          project: "${{ inputs.project }}"
+          project: "${{ inputs.subdir != '' && inputs.subdir || inputs.project }}"
 
       - name: "Check compat upper bounds"
         uses: ITensor/ITensorActions/.github/actions/check-compat-bounds@main
         with:
-          workspace-root: "${{ inputs.workspace-root }}"
+          workspace-root: "${{ inputs.subdir != '' && inputs.subdir || inputs.workspace-root }}"
           mode: "${{ inputs.mode }}"

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -113,9 +113,8 @@ jobs:
             end
           end
           subdir = get(ENV, "SUBDIR", "")
-          subdirs = isempty(subdir) ?
-              ["", "docs", "examples", "test"] :
-              [subdir, joinpath(subdir, "docs"), joinpath(subdir, "examples"), joinpath(subdir, "test")]
+          subdirs = ["", "docs", "examples", "test"]
+          isempty(subdir) || (subdirs = joinpath.(subdir, subdirs))
           token_owner = get(ENV, "TOKEN_OWNER", "")
           # If TOKEN_OWNER contains a JSON error body (happens when only GITHUB_TOKEN
           # is available, e.g. in private repos without COMPATHELPER_PAT), treat it as

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -14,11 +14,6 @@ on:
         default: ""
         required: false
         type: string
-      subdirs:
-        description: "Newline-separated list of subdirectories (relative to the repo root) whose Project.toml files should also be checked for compat updates. An empty entry represents the repo root itself. Default covers root + docs + examples + test."
-        default: "\ndocs\nexamples\ntest"
-        required: false
-        type: string
 
 jobs:
   compathelper:
@@ -78,7 +73,6 @@ jobs:
           # (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
           GITHUB_TOKEN: ${{ secrets.COMPATHELPER_PAT || secrets.GITHUB_TOKEN }}
           LOCALREGISTRY: ${{ inputs.localregistry }}
-          SUBDIRS: ${{ inputs.subdirs }}
           TOKEN_OWNER: ${{ steps.token-owner.outputs.login }}
         run: |
           import CompatHelper
@@ -112,7 +106,7 @@ jobs:
               push!(registries, Pkg.RegistrySpec(; url=registry_url, name=registry_name))
             end
           end
-          subdirs = string.(split(get(ENV, "SUBDIRS", ""), "\n"))
+          subdirs = ["", "docs", "examples", "test"]
           token_owner = get(ENV, "TOKEN_OWNER", "")
           # If TOKEN_OWNER contains a JSON error body (happens when only GITHUB_TOKEN
           # is available, e.g. in private repos without COMPATHELPER_PAT), treat it as

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -14,6 +14,11 @@ on:
         default: ""
         required: false
         type: string
+      subdirs:
+        description: "Newline-separated list of subdirectories (relative to the repo root) whose Project.toml files should also be checked for compat updates. An empty entry represents the repo root itself. Default covers root + docs + examples + test."
+        default: "\ndocs\nexamples\ntest"
+        required: false
+        type: string
 
 jobs:
   compathelper:
@@ -73,6 +78,7 @@ jobs:
           # (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
           GITHUB_TOKEN: ${{ secrets.COMPATHELPER_PAT || secrets.GITHUB_TOKEN }}
           LOCALREGISTRY: ${{ inputs.localregistry }}
+          SUBDIRS: ${{ inputs.subdirs }}
           TOKEN_OWNER: ${{ steps.token-owner.outputs.login }}
         run: |
           import CompatHelper
@@ -106,7 +112,7 @@ jobs:
               push!(registries, Pkg.RegistrySpec(; url=registry_url, name=registry_name))
             end
           end
-          subdirs = ["", "docs", "examples", "test"]
+          subdirs = string.(split(get(ENV, "SUBDIRS", ""), "\n"))
           token_owner = get(ENV, "TOKEN_OWNER", "")
           # If TOKEN_OWNER contains a JSON error body (happens when only GITHUB_TOKEN
           # is available, e.g. in private repos without COMPATHELPER_PAT), treat it as

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -14,6 +14,11 @@ on:
         default: ""
         required: false
         type: string
+      subdir:
+        description: "Subdirectory containing the package's Project.toml. When set, CompatHelper bumps `<subdir>/Project.toml` plus `<subdir>/{docs,examples,test}/Project.toml` if present. Empty (default) uses repo root."
+        default: ""
+        required: false
+        type: string
 
 jobs:
   compathelper:
@@ -73,6 +78,7 @@ jobs:
           # (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
           GITHUB_TOKEN: ${{ secrets.COMPATHELPER_PAT || secrets.GITHUB_TOKEN }}
           LOCALREGISTRY: ${{ inputs.localregistry }}
+          SUBDIR: ${{ inputs.subdir }}
           TOKEN_OWNER: ${{ steps.token-owner.outputs.login }}
         run: |
           import CompatHelper
@@ -106,7 +112,10 @@ jobs:
               push!(registries, Pkg.RegistrySpec(; url=registry_url, name=registry_name))
             end
           end
-          subdirs = ["", "docs", "examples", "test"]
+          subdir = get(ENV, "SUBDIR", "")
+          subdirs = isempty(subdir) ?
+              ["", "docs", "examples", "test"] :
+              [subdir, joinpath(subdir, "docs"), joinpath(subdir, "examples"), joinpath(subdir, "test")]
           token_owner = get(ENV, "TOKEN_OWNER", "")
           # If TOKEN_OWNER contains a JSON error body (happens when only GITHUB_TOKEN
           # is available, e.g. in private repos without COMPATHELPER_PAT), treat it as

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -22,11 +22,6 @@ on:
         required: false
         description: 'Add local registries hosted on GitHub. Specified by providing the url (https/ssh) to the repositories as a newline (\n) seperated list. User is responsible for setting up the necessary SSH-Keys to access the repositories if necessary.'
         default: ''
-      extra-dev-paths:
-        description: "Additional local package paths (relative to the repo root) to develop alongside the repository root before the docs build. Newline-separated list. Useful for repos with in-tree subpackages (e.g. ITensors.jl + NDTensors)."
-        default: ""
-        required: false
-        type: string
       self-hosted:
         description: "Run the job needs on a self hosted machine"
         default: false
@@ -116,7 +111,6 @@ jobs:
         shell: "bash"
         env:
           LOCALREGISTRY: ${{ inputs.localregistry }}
-          EXTRA_DEV_PATHS: ${{ inputs.extra-dev-paths }}
         # `doc-prefix` is rendered directly into the script body so that any
         # shell quoting in the caller's value (e.g. the single-quoted server
         # args of `xvfb-run -a -s '-screen 0 1024x768x24'`) is parsed by the
@@ -143,9 +137,7 @@ jobs:
               Pkg.Registry.add(Pkg.RegistrySpec(; url=repo_url))
             end
           end
-          dev_paths = [pwd(), split(get(ENV, "EXTRA_DEV_PATHS", ""), "\n")...]
-          filter!(!isempty, dev_paths)
-          Pkg.develop([Pkg.PackageSpec(; path) for path in dev_paths])
+          Pkg.develop(Pkg.PackageSpec(path=pwd()))
           # Explicit instantiate so docs/Manifest.toml resolution failures
           # (e.g. compat conflicts that would leave packages like Documenter
           # missing from the depot) surface here rather than silently

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -22,6 +22,11 @@ on:
         required: false
         description: 'Add local registries hosted on GitHub. Specified by providing the url (https/ssh) to the repositories as a newline (\n) seperated list. User is responsible for setting up the necessary SSH-Keys to access the repositories if necessary.'
         default: ''
+      extra-dev-paths:
+        description: "Additional local package paths (relative to the repo root) to develop alongside the repository root before the docs build. Newline-separated list. Useful for repos with in-tree subpackages (e.g. ITensors.jl + NDTensors)."
+        default: ""
+        required: false
+        type: string
       self-hosted:
         description: "Run the job needs on a self hosted machine"
         default: false
@@ -111,6 +116,7 @@ jobs:
         shell: "bash"
         env:
           LOCALREGISTRY: ${{ inputs.localregistry }}
+          EXTRA_DEV_PATHS: ${{ inputs.extra-dev-paths }}
         # `doc-prefix` is rendered directly into the script body so that any
         # shell quoting in the caller's value (e.g. the single-quoted server
         # args of `xvfb-run -a -s '-screen 0 1024x768x24'`) is parsed by the
@@ -137,7 +143,9 @@ jobs:
               Pkg.Registry.add(Pkg.RegistrySpec(; url=repo_url))
             end
           end
-          Pkg.develop(Pkg.PackageSpec(path=pwd()))
+          dev_paths = [pwd(), split(get(ENV, "EXTRA_DEV_PATHS", ""), "\n")...]
+          filter!(!isempty, dev_paths)
+          Pkg.develop([Pkg.PackageSpec(; path) for path in dev_paths])
           # Explicit instantiate so docs/Manifest.toml resolution failures
           # (e.g. compat conflicts that would leave packages like Documenter
           # missing from the depot) surface here rather than silently

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -23,22 +23,24 @@ on:
         required: false
         type: string
       subdir:
-        description: "Run the downstream tests against the package in this subdirectory. Also scopes the substantive-PR check to files under `<subdir>/`."
+        description: "Run the downstream tests against the package in this subdirectory."
         default: ""
         required: false
         type: string
-      exclude-subdirs:
-        description: "Negative scope for the substantive-PR check at root: newline-separated siblings to ignore."
+      paths:
+        description: "Newline-separated list of path prefixes / files defining positive scope for the substantive-PR check. A file triggers IntegrationTest iff it equals one of these paths or starts with `<path>/`. Empty means no positive-scope filter; the check falls back to `exclude-paths`. Mutually exclusive with `exclude-paths`."
         default: ""
+        required: false
+        type: string
+      exclude-paths:
+        description: "Newline-separated list of path prefixes / files defining negative scope for the substantive-PR check. A file does NOT trigger IntegrationTest if it matches one of these. Default ignores `.gitignore` and `.pre-commit-config.yaml`."
+        default: |
+          .gitignore
+          .pre-commit-config.yaml
         required: false
         type: string
       run-on-draft:
         description: "When true, run integration tests even on draft PRs"
-        default: false
-        required: false
-        type: boolean
-      run-on-nonsubstantive:
-        description: "Defaults to false so metadata-only changes don't trigger downstream tests."
         default: false
         required: false
         type: boolean
@@ -48,25 +50,8 @@ on:
         required: false
 
 jobs:
-  # Classify PR substance up front so the matrix and gate jobs can both
-  # gate on it. Non-substantive PRs (touching only `.github/**`,
-  # `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`) skip the matrix
-  # entirely by default; the gate then short-circuits to success.
-  classify:
-    name: "Classify PR substance"
-    runs-on: ubuntu-latest
-    outputs:
-      substantive: ${{ steps.classify.outputs.substantive }}
-    steps:
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
-        id: classify
-        with:
-          subdir: ${{ inputs.subdir }}
-          exclude-subdirs: ${{ inputs.exclude-subdirs }}
-
   integration-test:
     name: "${{ matrix.pkg }}"
-    needs: classify
     # Skip the matrix-driven leg entirely when `pkgs` is empty. Without this
     # guard, GitHub Actions reports an empty-matrix job as `failure`, which
     # propagates to the run's overall conclusion even though the aggregating
@@ -75,8 +60,7 @@ jobs:
     # the check is robust against whitespace / block-scalar style.
     if: |
       fromJSON(inputs.pkgs)[0] != null &&
-      (!github.event.pull_request.draft || inputs.run-on-draft) &&
-      (needs.classify.outputs.substantive == 'true' || inputs.run-on-nonsubstantive)
+      (!github.event.pull_request.draft || inputs.run-on-draft)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -86,6 +70,17 @@ jobs:
         pkg: ${{ fromJSON(inputs.pkgs) }}
 
     steps:
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
+        id: classify
+        with:
+          paths: ${{ inputs.paths }}
+          exclude-paths: ${{ inputs.exclude-paths }}
+
+      - name: "Skip on out-of-scope PR"
+        if: "${{ steps.classify.outputs.triggers != 'true' }}"
+        run: |
+          echo "PR has no changes in this caller's scope; integration test skipped."
+
       # Decide whether this matrix leg should run, and emit `skip=true|false`.
       # Skips when the entry is a URL that needs auth and the PR is from a
       # fork (no secrets are exposed to fork PRs under `pull_request:`).
@@ -95,6 +90,7 @@ jobs:
       # `workflow_dispatch` (where secrets are in scope).
       - name: "Decide whether to run"
         id: gate
+        if: "${{ steps.classify.outputs.triggers == 'true' }}"
         env:
           PKG: ${{ matrix.pkg }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
@@ -126,7 +122,7 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
       - name: "Record skipped dependency"
         id: skip_artifact
-        if: steps.gate.outputs.skip == 'true'
+        if: "${{ steps.classify.outputs.triggers == 'true' && steps.gate.outputs.skip == 'true' }}"
         env:
           PKG: ${{ matrix.pkg }}
         run: |
@@ -136,22 +132,22 @@ jobs:
           echo "key=$key" >> "$GITHUB_OUTPUT"
           echo "path=$path" >> "$GITHUB_OUTPUT"
       - name: "Upload skipped-dependency marker"
-        if: steps.gate.outputs.skip == 'true'
+        if: "${{ steps.classify.outputs.triggers == 'true' && steps.gate.outputs.skip == 'true' }}"
         uses: actions/upload-artifact@v7
         with:
           name: "integration-test-skip-${{ steps.skip_artifact.outputs.key }}"
           path: ${{ steps.skip_artifact.outputs.path }}
       - uses: actions/checkout@v6
-        if: steps.gate.outputs.skip != 'true'
+        if: "${{ steps.classify.outputs.triggers == 'true' && steps.gate.outputs.skip != 'true' }}"
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: julia-actions/setup-julia@v3
-        if: steps.gate.outputs.skip != 'true'
+        if: "${{ steps.classify.outputs.triggers == 'true' && steps.gate.outputs.skip != 'true' }}"
         with:
           version: ${{ inputs.julia-version }}
           arch: x64
       - name: "Configure git authentication for private repository"
-        if: steps.gate.outputs.skip != 'true'
+        if: "${{ steps.classify.outputs.triggers == 'true' && steps.gate.outputs.skip != 'true' }}"
         env:
           TOKEN: ${{ secrets.INTEGRATIONTEST_PAT }}
           PKG: ${{ matrix.pkg }}
@@ -162,7 +158,7 @@ jobs:
             fi
           fi
       - name: "Run the downstream tests"
-        if: steps.gate.outputs.skip != 'true'
+        if: "${{ steps.classify.outputs.triggers == 'true' && steps.gate.outputs.skip != 'true' }}"
         shell: julia --color=yes --project=downstream {0}
         env:
           PKG: ${{ matrix.pkg }}
@@ -228,7 +224,7 @@ jobs:
   # posts a passing check with the same name to satisfy branch protection.
   gate:
     name: "IntegrationTest"
-    needs: [classify, integration-test]
+    needs: integration-test
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
@@ -248,14 +244,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}
-          SUBSTANTIVE: ${{ needs.classify.outputs.substantive }}
-          RUN_ON_NONSUBSTANTIVE: ${{ inputs.run-on-nonsubstantive }}
         run: |
-          echo "test.result=$RESULT pkgs=$PKGS event=$EVENT_NAME substantive=$SUBSTANTIVE"
-          if [ "$SUBSTANTIVE" != "true" ] && [ "$RUN_ON_NONSUBSTANTIVE" != "true" ]; then
-            echo "PR is non-substantive (only .github/**, .pre-commit-config.yaml, .gitignore, LICENSE); IntegrationTest skipped without running. Set inputs.run-on-nonsubstantive=true on the caller to override."
-            exit 0
-          fi
+          echo "test.result=$RESULT pkgs=$PKGS event=$EVENT_NAME"
           pkg_count=$(printf '%s' "$PKGS" | jq 'length')
           if [ "$pkg_count" -eq 0 ]; then
             echo "No downstream integration tests configured; passing."

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -33,7 +33,7 @@ on:
         required: false
         type: boolean
       run-on-nonsubstantive:
-        description: "When true, run IntegrationTest even on PRs that only touch `.github/**`, `.pre-commit-config.yaml`, `.gitignore`, or `LICENSE`."
+        description: "Defaults to false so metadata-only changes don't trigger downstream tests."
         default: false
         required: false
         type: boolean

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -22,6 +22,11 @@ on:
         default: ""
         required: false
         type: string
+      subdir:
+        description: "Subdirectory containing the package-under-test's Project.toml, relative to the repo root. Empty (default) means use the repo root. When set (e.g. `NDTensors`), the workflow `Pkg.develop`s from that subdirectory instead, so multi-package repos can run an IntegrationTest matrix against an in-tree subpackage as the package under test."
+        default: ""
+        required: false
+        type: string
       run-on-draft:
         description: "When true, run integration tests even on draft PRs"
         default: false
@@ -135,6 +140,7 @@ jobs:
           PKG: ${{ matrix.pkg }}
           LOCALREGISTRY: ${{ inputs.localregistry }}
           EXTRA_DEV_PATHS: ${{ inputs.extra-dev-paths }}
+          PKG_DIR: ${{ inputs.subdir || '.' }}
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
         run: |
           using Pkg
@@ -148,7 +154,7 @@ jobs:
               Pkg.Registry.add(Pkg.RegistrySpec(; url=registry_url))
             end
           end
-          dev_paths = [".", split(get(ENV, "EXTRA_DEV_PATHS", ""), "\n")...]
+          dev_paths = [get(ENV, "PKG_DIR", "."), split(get(ENV, "EXTRA_DEV_PATHS", ""), "\n")...]
           filter!(!isempty, dev_paths)
           dev_specs = [PackageSpec(; path) for path in dev_paths]
           pkg = get(ENV, "PKG", "")

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -73,7 +73,11 @@ jobs:
       - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
         id: classify
         with:
-          paths: ${{ inputs.paths }}
+          # `subdir` (the in-tree package under test) is auto-appended
+          # to the positive scope so callers don't have to repeat it.
+          paths: |
+            ${{ inputs.subdir }}
+            ${{ inputs.paths }}
           exclude-paths: ${{ inputs.exclude-paths }}
 
       - name: "Skip on out-of-scope PR"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -32,14 +32,36 @@ on:
         default: false
         required: false
         type: boolean
+      run-on-nonsubstantive:
+        description: "When true, run IntegrationTest even on non-substantive PRs (those touching only `.github/**`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`). Defaults to false so metadata-only changes don't burn CI on downstream tests they can't possibly affect."
+        default: false
+        required: false
+        type: boolean
     secrets:
       INTEGRATIONTEST_PAT:
         description: "GitHub PAT for cloning private repositories via HTTPS."
         required: false
 
 jobs:
+  # Classify PR substance up front so the matrix and gate jobs can both
+  # gate on it. Non-substantive PRs (touching only `.github/**`,
+  # `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`) skip the matrix
+  # entirely by default; the gate then short-circuits to success.
+  classify:
+    name: "Classify PR substance"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      substantive: ${{ steps.classify.outputs.substantive }}
+    steps:
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
+        id: classify
+
   integration-test:
     name: "${{ matrix.pkg }}"
+    needs: classify
     # Skip the matrix-driven leg entirely when `pkgs` is empty. Without this
     # guard, GitHub Actions reports an empty-matrix job as `failure`, which
     # propagates to the run's overall conclusion even though the aggregating
@@ -48,7 +70,8 @@ jobs:
     # the check is robust against whitespace / block-scalar style.
     if: |
       fromJSON(inputs.pkgs)[0] != null &&
-      (!github.event.pull_request.draft || inputs.run-on-draft)
+      (!github.event.pull_request.draft || inputs.run-on-draft) &&
+      (needs.classify.outputs.substantive == 'true' || inputs.run-on-nonsubstantive)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -200,7 +223,7 @@ jobs:
   # posts a passing check with the same name to satisfy branch protection.
   gate:
     name: "IntegrationTest"
-    needs: integration-test
+    needs: [classify, integration-test]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
@@ -220,8 +243,14 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}
+          SUBSTANTIVE: ${{ needs.classify.outputs.substantive }}
+          RUN_ON_NONSUBSTANTIVE: ${{ inputs.run-on-nonsubstantive }}
         run: |
-          echo "test.result=$RESULT pkgs=$PKGS event=$EVENT_NAME"
+          echo "test.result=$RESULT pkgs=$PKGS event=$EVENT_NAME substantive=$SUBSTANTIVE"
+          if [ "$SUBSTANTIVE" != "true" ] && [ "$RUN_ON_NONSUBSTANTIVE" != "true" ]; then
+            echo "PR is non-substantive (only .github/**, .pre-commit-config.yaml, .gitignore, LICENSE); IntegrationTest skipped without running. Set inputs.run-on-nonsubstantive=true on the caller to override."
+            exit 0
+          fi
           pkg_count=$(printf '%s' "$PKGS" | jq 'length')
           if [ "$pkg_count" -eq 0 ]; then
             echo "No downstream integration tests configured; passing."

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -23,7 +23,7 @@ on:
         required: false
         type: string
       subdir:
-        description: "Subdirectory containing the package-under-test's Project.toml, relative to the repo root. Empty (default) means use the repo root. When set (e.g. `NDTensors`), the workflow `Pkg.develop`s from that subdirectory instead, so multi-package repos can run an IntegrationTest matrix against an in-tree subpackage as the package under test."
+        description: "Run the downstream tests against the package in this subdirectory."
         default: ""
         required: false
         type: string
@@ -33,7 +33,7 @@ on:
         required: false
         type: boolean
       run-on-nonsubstantive:
-        description: "When true, run IntegrationTest even on non-substantive PRs (those touching only `.github/**`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`). Defaults to false so metadata-only changes don't burn CI on downstream tests they can't possibly affect."
+        description: "When true, run IntegrationTest even on PRs that only touch `.github/**`, `.pre-commit-config.yaml`, `.gitignore`, or `LICENSE`."
         default: false
         required: false
         type: boolean

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -70,7 +70,7 @@ jobs:
         pkg: ${{ fromJSON(inputs.pkgs) }}
 
     steps:
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
         id: classify
         with:
           # `subdir` (the in-tree package under test) is auto-appended

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -23,7 +23,12 @@ on:
         required: false
         type: string
       subdir:
-        description: "Run the downstream tests against the package in this subdirectory."
+        description: "Run the downstream tests against the package in this subdirectory. Also scopes the substantive-PR check to files under `<subdir>/`."
+        default: ""
+        required: false
+        type: string
+      exclude-subdirs:
+        description: "Negative scope for the substantive-PR check at root: newline-separated siblings to ignore."
         default: ""
         required: false
         type: string
@@ -58,6 +63,9 @@ jobs:
     steps:
       - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
         id: classify
+        with:
+          subdir: ${{ inputs.subdir }}
+          exclude-subdirs: ${{ inputs.exclude-subdirs }}
 
   integration-test:
     name: "${{ matrix.pkg }}"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -55,9 +55,6 @@ jobs:
   classify:
     name: "Classify PR substance"
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
     outputs:
       substantive: ${{ steps.classify.outputs.substantive }}
     steps:

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -58,7 +58,7 @@ jobs:
     outputs:
       substantive: ${{ steps.classify.outputs.substantive }}
     steps:
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
         id: classify
         with:
           subdir: ${{ inputs.subdir }}

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -18,6 +18,11 @@ on:
         default: "/register"
         required: false
         type: string
+      subdir:
+        description: "Subdirectory containing the package's Project.toml, relative to the repo root. Default empty means register the root package. Set to e.g. 'NDTensors' to register an in-tree subpackage; the workflow then reads `package/<subdir>/Project.toml` and posts `@JuliaRegistrator register subdir=<subdir>` so JuliaRegistrator picks up the sub-package correctly."
+        default: ""
+        required: false
+        type: string
     secrets:
       # Only needed for the local-registry path (checkout + PR). Not needed for General.
       REGISTRATOR_PAT:
@@ -83,6 +88,7 @@ jobs:
         id: meta
         env:
           OLD_REF: ${{ github.event.before }}
+          SUBDIR: ${{ inputs.subdir }}
         shell: julia --color=yes {0}
         run: |
           using TOML
@@ -108,14 +114,17 @@ jobs:
           end
 
           let
-              new = TOML.parsefile("package/Project.toml")
+              subdir = get(ENV, "SUBDIR", "")
+              project_path = isempty(subdir) ? "Project.toml" : joinpath(subdir, "Project.toml")
+
+              new = TOML.parsefile(joinpath("package", project_path))
               name = get(new, "name", "")
               uuid = get(new, "uuid", "")
               newv_str = get(new, "version", "")
 
-              isempty(name) && error("Project.toml is missing name")
-              isempty(uuid) && error("Project.toml is missing uuid")
-              isempty(newv_str) && error("Project.toml is missing version")
+              isempty(name) && error("$project_path is missing name")
+              isempty(uuid) && error("$project_path is missing uuid")
+              isempty(newv_str) && error("$project_path is missing version")
 
               newv = parse_version(newv_str, "new")
               subject = replace(readchomp(`git -C package log -1 --pretty=%s HEAD`), ['\n','\r'] => ' ')
@@ -133,11 +142,11 @@ jobs:
               oldv_str = ""
               if !isempty(old_ref)
                   try
-                      old_toml = readchomp(`git -C package show $old_ref:Project.toml`)
+                      old_toml = readchomp(`git -C package show $old_ref:$project_path`)
                       oldv_str = get(TOML.parse(old_toml), "version", "")
                   catch err
                       # Don't hard-fail on missing old Project.toml; just skip strict validation.
-                      println(stderr, "Warning: could not read Project.toml at ref '$old_ref' (treating as no prior version): $err")
+                      println(stderr, "Warning: could not read $project_path at ref '$old_ref' (treating as no prior version): $err")
                       oldv_str = ""
                   end
               end
@@ -217,9 +226,14 @@ jobs:
           IS_BREAKING: ${{ steps.meta.outputs.is_breaking }}
           SUBJECT: ${{ steps.meta.outputs.subject }}
           NEW_VERSION: ${{ steps.meta.outputs.new_version }}
+          SUBDIR: ${{ inputs.subdir }}
         run: |
           {
-            echo "@JuliaRegistrator register"
+            if [ -n "$SUBDIR" ]; then
+              echo "@JuliaRegistrator register subdir=$SUBDIR"
+            else
+              echo "@JuliaRegistrator register"
+            fi
             if [ "$IS_BREAKING" = "true" ]; then
               echo ""
               echo "Release notes:"
@@ -336,6 +350,8 @@ jobs:
 
       - name: "Update local registry"
         if: steps.meta.outputs.route == 'local'
+        env:
+          SUBDIR: ${{ inputs.subdir }}
         shell: julia --color=yes {0}
         run: |
           import Pkg
@@ -344,7 +360,9 @@ jobs:
                                   uuid="89398ba2-070a-4b16-a995-9893c55d93cf",
                                   version="0.5.7"))
           using LocalRegistry
-          register("./package"; registry="./registry", commit=false, push=false)
+          subdir = get(ENV, "SUBDIR", "")
+          pkg_path = isempty(subdir) ? "./package" : joinpath("./package", subdir)
+          register(pkg_path; registry="./registry", commit=false, push=false)
 
       - name: "Create PR to registry"
         if: steps.meta.outputs.route == 'local'

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -130,9 +130,6 @@ jobs:
   classify:
     name: "Classify PR substance"
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
     outputs:
       substantive: ${{ steps.classify.outputs.substantive }}
     steps:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -133,7 +133,7 @@ jobs:
     outputs:
       substantive: ${{ steps.classify.outputs.substantive }}
     steps:
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
         id: classify
         with:
           subdir: ${{ inputs.subdir }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -143,7 +143,11 @@ jobs:
       - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
         id: classify
         with:
-          paths: ${{ inputs.paths }}
+          # `subdir` (the package being tested) is auto-appended to
+          # the positive scope so callers don't have to repeat it.
+          paths: |
+            ${{ inputs.subdir }}
+            ${{ inputs.paths }}
           exclude-paths: ${{ inputs.exclude-paths }}
 
       - name: "Skip on out-of-scope PR"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -140,7 +140,7 @@ jobs:
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
         id: classify
         with:
           # `subdir` (the package being tested) is auto-appended to

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -157,10 +157,12 @@ jobs:
         shell: julia --color=yes {0}
         env:
           EXTRA_DEV_PATHS: ${{ inputs.extra-dev-paths }}
+          PROJECT: ${{ inputs.project }}
         run: |
           using Pkg
           dev_paths = filter(!isempty, string.(split(get(ENV, "EXTRA_DEV_PATHS", ""), "\n")))
-          Pkg.activate(".")
+          project = get(ENV, "PROJECT", "@.")
+          Pkg.activate(project)
           Pkg.develop([Pkg.PackageSpec(; path) for path in dev_paths])
 
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -12,11 +12,6 @@ on:
         description: "Architecture of Julia to be used"
         required: false
         type: string
-      project:
-        description: "The value is passed to Julia's `--project` flag"
-        default: '@.'
-        required: false
-        type: string
       group:
         description: "The 'GROUP' of tests that need to be run. This will requires an ENV `GROUP` to be (conditionally) defined within your package tests as well to selectively run groups of tests"
         default: ""
@@ -72,6 +67,16 @@ on:
         default: ""
         required: false
         type: string
+      subdir:
+        description: "Subdirectory containing the package's Project.toml. When set, Julia activates `<subdir>` and classify-pr scopes the substantive-PR check to files under `<subdir>/`. Empty (default) activates the repo root."
+        default: ""
+        required: false
+        type: string
+      exclude-subdirs:
+        description: "Negative scope for the substantive-PR check at root: newline-separated siblings to ignore. Skip Tests when changes are confined to `.github/**`/`.pre-commit-config.yaml`/`.gitignore`/`LICENSE` plus any of the listed siblings."
+        default: ""
+        required: false
+        type: string
       continue-on-error:
         description: "Prevent the workflow run from failing if/when the job fails"
         required: false
@@ -111,14 +116,41 @@ on:
         required: true
 
 jobs:
-  tests:
-    name: "Julia ${{ inputs.julia-version }} - ${{ inputs.self-hosted && 'self-hosted' || inputs.os }} ${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
+  # Classify PR substance up front when per-package scoping is requested
+  # (`subdir` or `exclude-subdirs` set). Tests reads the result to skip
+  # PRs whose substantive changes are outside this package's scope. When
+  # neither input is set the classify-pr action runs in its global mode
+  # but Tests ignores its result, preserving today's "run on every PR"
+  # behavior for existing single-package consumers.
+  classify:
+    name: "Classify PR substance"
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: >-
-      !github.event.pull_request.draft
-      || inputs.run-all-on-draft
-      || (inputs.os == 'ubuntu-latest' && inputs.julia-version == '1')
+      pull-requests: read
+    outputs:
+      substantive: ${{ steps.classify.outputs.substantive }}
+    steps:
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
+        id: classify
+        with:
+          subdir: ${{ inputs.subdir }}
+          exclude-subdirs: ${{ inputs.exclude-subdirs }}
+
+  tests:
+    name: "Julia ${{ inputs.julia-version }} - ${{ inputs.self-hosted && 'self-hosted' || inputs.os }} ${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
+    needs: classify
+    permissions:
+      contents: read
+    if: |
+      (
+        !github.event.pull_request.draft
+        || inputs.run-all-on-draft
+        || (inputs.os == 'ubuntu-latest' && inputs.julia-version == '1')
+      ) && (
+        (inputs.subdir == '' && inputs.exclude-subdirs == '')
+        || needs.classify.outputs.substantive == 'true'
+      )
     continue-on-error: ${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
     timeout-minutes: ${{ inputs.timeout-minutes }}
@@ -151,6 +183,7 @@ jobs:
         if: "${{ inputs.buildpkg }}"
         with:
           localregistry: "${{ inputs.localregistry }}"
+          project: "${{ inputs.subdir != '' && inputs.subdir || '@.' }}"
 
       - name: "Export extra environment variables"
         if: "${{ inputs.extra-env != '' }}"
@@ -163,7 +196,7 @@ jobs:
       - name: "Run tests ${{ inputs.self-hosted && '' || format('on {0}', inputs.os) }} with Julia v${{ inputs.julia-version }}"
         uses: julia-actions/julia-runtest@v1
         with:
-          project: "${{ inputs.project }}"
+          project: "${{ inputs.subdir != '' && inputs.subdir || '@.' }}"
           depwarn: "${{ inputs.julia-runtest-depwarn }}"
           coverage: "${{ inputs.coverage }}"
           prefix: "${{ inputs.test-prefix }}"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -72,11 +72,6 @@ on:
         default: ""
         required: false
         type: string
-      extra-dev-paths:
-        description: "Additional local package paths (relative to the repo root) to `Pkg.develop()` into the active project before running tests. Newline-separated list. Useful for repos with in-tree subpackages (e.g. ITensors.jl + NDTensors) where the in-tree dep must shadow any registered version during testing."
-        default: ""
-        required: false
-        type: string
       continue-on-error:
         description: "Prevent the workflow run from failing if/when the job fails"
         required: false
@@ -151,19 +146,6 @@ jobs:
         if: "${{ inputs.cache }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: "Pkg.develop extra paths"
-        if: "${{ inputs.extra-dev-paths != '' }}"
-        shell: julia --color=yes {0}
-        env:
-          EXTRA_DEV_PATHS: ${{ inputs.extra-dev-paths }}
-          PROJECT: ${{ inputs.project }}
-        run: |
-          using Pkg
-          dev_paths = filter(!isempty, string.(split(get(ENV, "EXTRA_DEV_PATHS", ""), "\n")))
-          project = get(ENV, "PROJECT", "@.")
-          Pkg.activate(project)
-          Pkg.develop([Pkg.PackageSpec(; path) for path in dev_paths])
 
       - uses: julia-actions/julia-buildpkg@v1
         if: "${{ inputs.buildpkg }}"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -67,6 +67,11 @@ on:
         default: "yes"
         required: false
         type: string
+      test-args:
+        description: "Newline-separated list of arguments passed to `Pkg.test(; test_args=...)`. Surfaces julia-actions/julia-runtest's `test_args` input. Useful when `runtests.jl` selects test groups via ARGS rather than the GROUP env-var."
+        default: ""
+        required: false
+        type: string
       continue-on-error:
         description: "Prevent the workflow run from failing if/when the job fails"
         required: false
@@ -162,6 +167,7 @@ jobs:
           depwarn: "${{ inputs.julia-runtest-depwarn }}"
           coverage: "${{ inputs.coverage }}"
           prefix: "${{ inputs.test-prefix }}"
+          test_args: "${{ inputs.test-args }}"
           # On LTS, accept that newer dep versions may not be reachable —
           # let Pkg resolve to whatever satisfies both the workspace compat
           # and transitive constraints. `auto` (the default) would otherwise

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -73,12 +73,7 @@ on:
         required: false
         type: string
       subdir:
-        description: "Subdirectory containing the package's Project.toml. When set, Julia activates `<subdir>` and classify-pr scopes the substantive-PR check to files under `<subdir>/`. Empty (default) activates the repo root."
-        default: ""
-        required: false
-        type: string
-      exclude-subdirs:
-        description: "Negative scope for the substantive-PR check at root: newline-separated siblings to ignore. Skip Tests when changes are confined to `.github/**`/`.pre-commit-config.yaml`/`.gitignore`/`LICENSE` plus any of the listed siblings."
+        description: "Subdirectory containing the package's Project.toml. When set, Julia activates `<subdir>` for buildpkg and runtest. Empty (default) activates the repo root."
         default: ""
         required: false
         type: string
@@ -121,38 +116,14 @@ on:
         required: true
 
 jobs:
-  # Classify PR substance up front when per-package scoping is requested
-  # (`subdir` or `exclude-subdirs` set). Tests reads the result to skip
-  # PRs whose substantive changes are outside this package's scope. When
-  # neither input is set the classify-pr action runs in its global mode
-  # but Tests ignores its result, preserving today's "run on every PR"
-  # behavior for existing single-package consumers.
-  classify:
-    name: "Classify PR substance"
-    runs-on: ubuntu-latest
-    outputs:
-      substantive: ${{ steps.classify.outputs.substantive }}
-    steps:
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
-        id: classify
-        with:
-          subdir: ${{ inputs.subdir }}
-          exclude-subdirs: ${{ inputs.exclude-subdirs }}
-
   tests:
     name: "Julia ${{ inputs.julia-version }} - ${{ inputs.self-hosted && 'self-hosted' || inputs.os }} ${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
-    needs: classify
     permissions:
       contents: read
-    if: |
-      (
-        !github.event.pull_request.draft
-        || inputs.run-all-on-draft
-        || (inputs.os == 'ubuntu-latest' && inputs.julia-version == '1')
-      ) && (
-        (inputs.subdir == '' && inputs.exclude-subdirs == '')
-        || needs.classify.outputs.substantive == 'true'
-      )
+    if: >-
+      !github.event.pull_request.draft
+      || inputs.run-all-on-draft
+      || (inputs.os == 'ubuntu-latest' && inputs.julia-version == '1')
     continue-on-error: ${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
     timeout-minutes: ${{ inputs.timeout-minutes }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -72,6 +72,11 @@ on:
         default: ""
         required: false
         type: string
+      extra-dev-paths:
+        description: "Additional local package paths (relative to the repo root) to `Pkg.develop()` into the active project before running tests. Newline-separated list. Useful for repos with in-tree subpackages (e.g. ITensors.jl + NDTensors) where the in-tree dep must shadow any registered version during testing."
+        default: ""
+        required: false
+        type: string
       continue-on-error:
         description: "Prevent the workflow run from failing if/when the job fails"
         required: false
@@ -146,6 +151,17 @@ jobs:
         if: "${{ inputs.cache }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Pkg.develop extra paths"
+        if: "${{ inputs.extra-dev-paths != '' }}"
+        shell: julia --color=yes {0}
+        env:
+          EXTRA_DEV_PATHS: ${{ inputs.extra-dev-paths }}
+        run: |
+          using Pkg
+          dev_paths = filter(!isempty, string.(split(get(ENV, "EXTRA_DEV_PATHS", ""), "\n")))
+          Pkg.activate(".")
+          Pkg.develop([Pkg.PackageSpec(; path) for path in dev_paths])
 
       - uses: julia-actions/julia-buildpkg@v1
         if: "${{ inputs.buildpkg }}"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -77,6 +77,18 @@ on:
         default: ""
         required: false
         type: string
+      paths:
+        description: "Newline-separated list of path prefixes / files defining positive scope for the substantive-PR check. A file triggers tests iff it equals one of these paths or starts with `<path>/`. Empty means no positive-scope filter; the check falls back to `exclude-paths`. Mutually exclusive with `exclude-paths`."
+        default: ""
+        required: false
+        type: string
+      exclude-paths:
+        description: "Newline-separated list of path prefixes / files defining negative scope for the substantive-PR check. A file does NOT trigger if it matches one of these. Default ignores `.gitignore` and `.pre-commit-config.yaml`. Override entirely (e.g. add a sibling subpackage and re-list defaults if you want them kept)."
+        default: |
+          .gitignore
+          .pre-commit-config.yaml
+        required: false
+        type: string
       continue-on-error:
         description: "Prevent the workflow run from failing if/when the job fails"
         required: false
@@ -128,10 +140,22 @@ jobs:
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
+        id: classify
+        with:
+          paths: ${{ inputs.paths }}
+          exclude-paths: ${{ inputs.exclude-paths }}
+
+      - name: "Skip on out-of-scope PR"
+        if: "${{ steps.classify.outputs.triggers != 'true' }}"
+        run: |
+          echo "PR has no changes in this caller's scope; tests skipped."
+
       - uses: actions/checkout@v6
+        if: "${{ steps.classify.outputs.triggers == 'true' }}"
 
       - name: "Install apt packages"
-        if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"
+        if: "${{ steps.classify.outputs.triggers == 'true' && inputs.apt-packages != '' && runner.os == 'Linux' }}"
         env:
           APT_PACKAGES: ${{ inputs.apt-packages }}
         run: |
@@ -142,24 +166,25 @@ jobs:
           sudo apt-get install -y $APT_PACKAGES
 
       - name: "Setup Julia ${{ inputs.julia-version }}"
+        if: "${{ steps.classify.outputs.triggers == 'true' }}"
         uses: julia-actions/setup-julia@v3
         with:
           version: "${{ inputs.julia-version }}"
           arch: "${{ inputs.julia-arch || runner.arch }}"
 
       - uses: julia-actions/cache@v2
-        if: "${{ inputs.cache }}"
+        if: "${{ steps.classify.outputs.triggers == 'true' && inputs.cache }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
       - uses: julia-actions/julia-buildpkg@v1
-        if: "${{ inputs.buildpkg }}"
+        if: "${{ steps.classify.outputs.triggers == 'true' && inputs.buildpkg }}"
         with:
           localregistry: "${{ inputs.localregistry }}"
           project: "${{ inputs.subdir != '' && inputs.subdir || inputs.project }}"
 
       - name: "Export extra environment variables"
-        if: "${{ inputs.extra-env != '' }}"
+        if: "${{ steps.classify.outputs.triggers == 'true' && inputs.extra-env != '' }}"
         shell: "bash"
         env:
           EXTRA_ENV: ${{ inputs.extra-env }}
@@ -167,6 +192,7 @@ jobs:
           printf '%s\n' "$EXTRA_ENV" >> "$GITHUB_ENV"
 
       - name: "Run tests ${{ inputs.self-hosted && '' || format('on {0}', inputs.os) }} with Julia v${{ inputs.julia-version }}"
+        if: "${{ steps.classify.outputs.triggers == 'true' }}"
         uses: julia-actions/julia-runtest@v1
         with:
           project: "${{ inputs.subdir != '' && inputs.subdir || inputs.project }}"
@@ -186,20 +212,20 @@ jobs:
           JULIA_NUM_THREADS: "${{ inputs.nthreads }}"
 
       - name: "Upload artifacts"
-        if: "${{ always() && inputs.upload-artifacts-path != '' }}"
+        if: "${{ always() && steps.classify.outputs.triggers == 'true' && inputs.upload-artifacts-path != '' }}"
         uses: actions/upload-artifact@v7
         with:
           name: "artifacts-${{ inputs.os }}-julia-${{ inputs.julia-version }}${{ inputs.group != '' && format('-{0}', inputs.group) || '' }}"
           path: "${{ inputs.upload-artifacts-path }}"
 
       - uses: julia-actions/julia-processcoverage@v1
-        if: "${{ inputs.coverage }}"
+        if: "${{ steps.classify.outputs.triggers == 'true' && inputs.coverage }}"
         with:
           directories: "${{ inputs.coverage-directories }}"
 
       - name: "Report coverage with Codecov"
         uses: codecov/codecov-action@v6
-        if: "${{ inputs.coverage }}"
+        if: "${{ steps.classify.outputs.triggers == 'true' && inputs.coverage }}"
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -12,6 +12,11 @@ on:
         description: "Architecture of Julia to be used"
         required: false
         type: string
+      project:
+        description: "Deprecated alias for `subdir`. Value passed to Julia's `--project` flag. Set `subdir` instead. Will be removed in a future major release."
+        default: "@."
+        required: false
+        type: string
       group:
         description: "The 'GROUP' of tests that need to be run. This will requires an ENV `GROUP` to be (conditionally) defined within your package tests as well to selectively run groups of tests"
         default: ""
@@ -183,7 +188,7 @@ jobs:
         if: "${{ inputs.buildpkg }}"
         with:
           localregistry: "${{ inputs.localregistry }}"
-          project: "${{ inputs.subdir != '' && inputs.subdir || '@.' }}"
+          project: "${{ inputs.subdir != '' && inputs.subdir || inputs.project }}"
 
       - name: "Export extra environment variables"
         if: "${{ inputs.extra-env != '' }}"
@@ -196,7 +201,7 @@ jobs:
       - name: "Run tests ${{ inputs.self-hosted && '' || format('on {0}', inputs.os) }} with Julia v${{ inputs.julia-version }}"
         uses: julia-actions/julia-runtest@v1
         with:
-          project: "${{ inputs.subdir != '' && inputs.subdir || '@.' }}"
+          project: "${{ inputs.subdir != '' && inputs.subdir || inputs.project }}"
           depwarn: "${{ inputs.julia-runtest-depwarn }}"
           coverage: "${{ inputs.coverage }}"
           prefix: "${{ inputs.test-prefix }}"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -14,13 +14,21 @@ on:
         required: false
         type: string
       subdir:
-        description: "Subdirectory containing the package's Project.toml. When set, VersionCheck reads `<subdir>/Project.toml` and classify-pr scopes the substantive-PR check to files under `<subdir>/`. Empty (default) reads root Project.toml."
+        description: "Subdirectory containing the package's Project.toml. When set, VersionCheck reads `<subdir>/Project.toml` for the version-bump check. Empty (default) reads root Project.toml."
         default: ""
         required: false
         type: string
-      exclude-subdirs:
-        description: "Negative scope for the substantive-PR check at root: newline-separated siblings to ignore."
+      paths:
+        description: "Newline-separated list of path prefixes / files defining positive scope for the substantive-PR check. A file triggers VersionCheck iff it equals one of these paths or starts with `<path>/`. Empty means no positive-scope filter; the check falls back to `exclude-paths`. Mutually exclusive with `exclude-paths`."
         default: ""
+        required: false
+        type: string
+      exclude-paths:
+        description: "Newline-separated list of path prefixes / files defining negative scope for the substantive-PR check. A file does NOT trigger VersionCheck if it matches one of these. Default ignores `.gitignore`, `.pre-commit-config.yaml`, and `.github` (workflow / config metadata changes don't require a version bump)."
+        default: |
+          .gitignore
+          .pre-commit-config.yaml
+          .github
         required: false
         type: string
 
@@ -38,25 +46,25 @@ jobs:
       - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
         id: classify
         with:
-          subdir: ${{ inputs.subdir }}
-          exclude-subdirs: ${{ inputs.exclude-subdirs }}
+          paths: ${{ inputs.paths }}
+          exclude-paths: ${{ inputs.exclude-paths }}
 
-      - name: "Skip version check on non-substantive PR"
-        if: steps.classify.outputs.substantive != 'true'
+      - name: "Skip version check on out-of-scope PR"
+        if: steps.classify.outputs.triggers != 'true'
         run: |
-          echo "PR has no substantive changes in scope; no version bump required. Reporting success."
+          echo "PR has no changes in this caller's scope; no version bump required. Reporting success."
 
       - name: "Fetch base branch"
-        if: steps.classify.outputs.substantive == 'true'
+        if: steps.classify.outputs.triggers == 'true'
         run: git fetch --depth=1 origin "${{ github.base_ref }}"
 
       - uses: julia-actions/setup-julia@v3
-        if: steps.classify.outputs.substantive == 'true'
+        if: steps.classify.outputs.triggers == 'true'
         with:
           version: ${{ inputs.julia-version }}
 
       - name: "Check version was bumped"
-        if: steps.classify.outputs.substantive == 'true'
+        if: steps.classify.outputs.triggers == 'true'
         shell: julia --color=yes {0}
         env:
           SUBDIR: ${{ inputs.subdir }}

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -13,6 +13,16 @@ on:
         default: ""
         required: false
         type: string
+      subdir:
+        description: "Subdirectory containing the package's Project.toml. When set, VersionCheck reads `<subdir>/Project.toml` and classify-pr scopes the substantive-PR check to files under `<subdir>/`. Empty (default) reads root Project.toml."
+        default: ""
+        required: false
+        type: string
+      exclude-subdirs:
+        description: "Negative scope for the substantive-PR check at root: newline-separated siblings to ignore."
+        default: ""
+        required: false
+        type: string
 
 jobs:
   version-check:
@@ -27,12 +37,14 @@ jobs:
 
       - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
         id: classify
+        with:
+          subdir: ${{ inputs.subdir }}
+          exclude-subdirs: ${{ inputs.exclude-subdirs }}
 
       - name: "Skip version check on non-substantive PR"
         if: steps.classify.outputs.substantive != 'true'
         run: |
-          echo "PR classified as non-substantive (only .github/**, .pre-commit-config.yaml, .gitignore, LICENSE)."
-          echo "No version bump is required. Reporting success without running the real check."
+          echo "PR has no substantive changes in scope; no version bump required. Reporting success."
 
       - name: "Fetch base branch"
         if: steps.classify.outputs.substantive == 'true'
@@ -46,26 +58,31 @@ jobs:
       - name: "Check version was bumped"
         if: steps.classify.outputs.substantive == 'true'
         shell: julia --color=yes {0}
+        env:
+          SUBDIR: ${{ inputs.subdir }}
         run: |
           using TOML
 
+          subdir = get(ENV, "SUBDIR", "")
+          project_path = isempty(subdir) ? "Project.toml" : joinpath(subdir, "Project.toml")
+
           base_ref = ENV["GITHUB_BASE_REF"]
           base_project_text = try
-              read(`git show "origin/$base_ref:Project.toml"`, String)
+              read(`git show "origin/$base_ref:$project_path"`, String)
           catch err
-              println("Could not read Project.toml on origin/$base_ref ($err); skipping check.")
+              println("Could not read $project_path on origin/$base_ref ($err); skipping check.")
               exit(0)
           end
           base_project = TOML.parse(base_project_text)
-          current_project = TOML.parse(read("Project.toml", String))
+          current_project = TOML.parse(read(project_path, String))
 
           if !haskey(base_project, "version")
-              println("Base branch Project.toml has no version field; skipping check.")
+              println("Base branch $project_path has no version field; skipping check.")
               exit(0)
           end
           if !haskey(current_project, "version")
               error(
-                  "Project.toml on this branch has no version field, but the base " *
+                  "$project_path on this branch has no version field, but the base " *
                   "branch ($base_ref) does. Restore the version field and bump it."
               )
           end
@@ -75,13 +92,13 @@ jobs:
 
           if current_version > base_version
               println(
-                  "OK: Project.toml version bumped from $base_version " *
+                  "OK: $project_path version bumped from $base_version " *
                   "(origin/$base_ref) to $current_version (PR head)."
               )
           else
               error(
-                  "Project.toml version was not bumped. Current version $current_version " *
+                  "$project_path version was not bumped. Current version $current_version " *
                   "is not greater than the version $base_version on the base branch " *
-                  "($base_ref). Bump the version in Project.toml."
+                  "($base_ref). Bump the version in $project_path."
               )
           end

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
         id: classify
         with:
           # `subdir` (the in-tree package whose Project.toml is checked) is

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -13,6 +13,11 @@ on:
         default: ""
         required: false
         type: string
+      subdirs:
+        description: "Newline-separated list of subdirectories that contain in-tree subpackages with their own Project.toml. When set, each subdir's Project.toml is checked for a version bump independently of the root Project.toml. Each project's check fires only if the PR has substantive changes inside that project's scope: a file in `<subdir>/**` for a named subdir, or a file outside (`.github/**`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`, and any named subdir) for the root."
+        default: ""
+        required: false
+        type: string
 
 jobs:
   version-check:
@@ -25,63 +30,118 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
-        id: classify
-
-      - name: "Skip version check on non-substantive PR"
-        if: steps.classify.outputs.substantive != 'true'
-        run: |
-          echo "PR classified as non-substantive (only .github/**, .pre-commit-config.yaml, .gitignore, LICENSE)."
-          echo "No version bump is required. Reporting success without running the real check."
-
       - name: "Fetch base branch"
-        if: steps.classify.outputs.substantive == 'true'
+        if: github.event_name == 'pull_request'
         run: git fetch --depth=1 origin "${{ github.base_ref }}"
 
       - uses: julia-actions/setup-julia@v3
-        if: steps.classify.outputs.substantive == 'true'
+        if: github.event_name == 'pull_request'
         with:
           version: ${{ inputs.julia-version }}
 
-      - name: "Check version was bumped"
-        if: steps.classify.outputs.substantive == 'true'
+      - name: "Check version bumps per project"
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+          SUBDIRS: ${{ inputs.subdirs }}
         shell: julia --color=yes {0}
         run: |
           using TOML
 
-          base_ref = ENV["GITHUB_BASE_REF"]
-          base_project_text = try
-              read(`git show "origin/$base_ref:Project.toml"`, String)
-          catch err
-              println("Could not read Project.toml on origin/$base_ref ($err); skipping check.")
-              exit(0)
-          end
-          base_project = TOML.parse(base_project_text)
-          current_project = TOML.parse(read("Project.toml", String))
+          # Substantive-file rules: at the repo root, ignore CI/config
+          # metadata files. Inside a named subdir, every change counts.
+          # Per-subdir classification means each project (root + each
+          # named subdir) gets its own scope and is checked
+          # independently — root bump required only when files outside
+          # the metadata set AND outside any named subdir change; named
+          # subdir bump required only when files inside that subdir
+          # change.
+          const IGNORE_AT_ROOT = (".github/", ".pre-commit-config.yaml", ".gitignore", "LICENSE")
 
-          if !haskey(base_project, "version")
-              println("Base branch Project.toml has no version field; skipping check.")
-              exit(0)
-          end
-          if !haskey(current_project, "version")
-              error(
-                  "Project.toml on this branch has no version field, but the base " *
-                  "branch ($base_ref) does. Restore the version field and bump it."
-              )
+          subdirs = filter(!isempty, string.(split(get(ENV, "SUBDIRS", ""), "\n")))
+          projects = vcat([""], subdirs)
+
+          base_ref = ENV["BASE_REF"]
+          repo = ENV["REPO"]
+          pr_number = ENV["PR_NUMBER"]
+
+          files_text = read(`gh api --paginate "repos/$repo/pulls/$pr_number/files" --jq ".[].filename"`, String)
+          changed_files = filter(!isempty, string.(split(strip(files_text), '\n')))
+          println("Changed files in PR #$pr_number:")
+          for f in changed_files
+              println("  $f")
           end
 
-          base_version = VersionNumber(base_project["version"])
-          current_version = VersionNumber(current_project["version"])
-
-          if current_version > base_version
-              println(
-                  "OK: Project.toml version bumped from $base_version " *
-                  "(origin/$base_ref) to $current_version (PR head)."
-              )
-          else
-              error(
-                  "Project.toml version was not bumped. Current version $current_version " *
-                  "is not greater than the version $base_version on the base branch " *
-                  "($base_ref). Bump the version in Project.toml."
-              )
+          function in_scope(file, project, all_subdirs)
+              if isempty(project)
+                  any(startswith(file, p) || file == p for p in IGNORE_AT_ROOT) && return false
+                  any(startswith(file, sd * "/") for sd in all_subdirs) && return false
+                  return true
+              else
+                  return startswith(file, project * "/")
+              end
           end
+
+          function project_path(project)
+              isempty(project) ? "Project.toml" : joinpath(project, "Project.toml")
+          end
+
+          function check_project(project, all_subdirs, base_ref, files)
+              path = project_path(project)
+              label = isempty(project) ? "root" : project
+
+              substantive = filter(f -> in_scope(f, project, all_subdirs), files)
+              if isempty(substantive)
+                  println("$label: no substantive changes; skipping version-bump check.")
+                  return true
+              end
+
+              println("$label: substantive files changed:")
+              for f in substantive
+                  println("  $f")
+              end
+
+              base_text = try
+                  read(`git show "origin/$base_ref:$path"`, String)
+              catch err
+                  println("$label: could not read $path on origin/$base_ref ($err); skipping check.")
+                  return true
+              end
+
+              if !isfile(path)
+                  println("$label: $path is missing in PR head; skipping check.")
+                  return true
+              end
+
+              base_proj = TOML.parse(base_text)
+              current_proj = TOML.parse(read(path, String))
+
+              if !haskey(base_proj, "version")
+                  println("$label: base $path has no version field; skipping check.")
+                  return true
+              end
+              if !haskey(current_proj, "version")
+                  println(stderr, "ERROR: $label: $path on PR head has no version field, but base does. Restore the version and bump it.")
+                  return false
+              end
+
+              base_v = VersionNumber(base_proj["version"])
+              current_v = VersionNumber(current_proj["version"])
+
+              if current_v > base_v
+                  println("$label: $path bumped from $base_v to $current_v. OK.")
+                  return true
+              else
+                  println(stderr, "ERROR: $label has substantive changes but $path version was not bumped (current $current_v not > base $base_v).")
+                  return false
+              end
+          end
+
+          all_pass = true
+          for p in projects
+              all_pass &= check_project(p, subdirs, base_ref, changed_files)
+          end
+          all_pass || error("VersionCheck failed; see errors above.")

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -140,8 +140,6 @@ jobs:
               end
           end
 
-          all_pass = true
-          for p in projects
-              all_pass &= check_project(p, subdirs, base_ref, changed_files)
-          end
-          all_pass || error("VersionCheck failed; see errors above.")
+          # Evaluate every project so all errors surface before failing.
+          results = [check_project(p, subdirs, base_ref, changed_files) for p in projects]
+          all(results) || error("VersionCheck failed; see errors above.")

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -46,7 +46,12 @@ jobs:
       - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
         id: classify
         with:
-          paths: ${{ inputs.paths }}
+          # `subdir` (the in-tree package whose Project.toml is checked) is
+          # auto-appended to the positive scope so callers don't have to
+          # repeat it.
+          paths: |
+            ${{ inputs.subdir }}
+            ${{ inputs.paths }}
           exclude-paths: ${{ inputs.exclude-paths }}
 
       - name: "Skip version check on out-of-scope PR"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -13,11 +13,6 @@ on:
         default: ""
         required: false
         type: string
-      subdirs:
-        description: "Newline-separated list of subdirectories that contain in-tree subpackages with their own Project.toml. When set, each subdir's Project.toml is checked for a version bump independently of the root Project.toml. Each project's check fires only if the PR has substantive changes inside that project's scope: a file in `<subdir>/**` for a named subdir, or a file outside (`.github/**`, `.pre-commit-config.yaml`, `.gitignore`, `LICENSE`, and any named subdir) for the root."
-        default: ""
-        required: false
-        type: string
 
 jobs:
   version-check:
@@ -30,116 +25,63 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
+        id: classify
+
+      - name: "Skip version check on non-substantive PR"
+        if: steps.classify.outputs.substantive != 'true'
+        run: |
+          echo "PR classified as non-substantive (only .github/**, .pre-commit-config.yaml, .gitignore, LICENSE)."
+          echo "No version bump is required. Reporting success without running the real check."
+
       - name: "Fetch base branch"
-        if: github.event_name == 'pull_request'
+        if: steps.classify.outputs.substantive == 'true'
         run: git fetch --depth=1 origin "${{ github.base_ref }}"
 
       - uses: julia-actions/setup-julia@v3
-        if: github.event_name == 'pull_request'
+        if: steps.classify.outputs.substantive == 'true'
         with:
           version: ${{ inputs.julia-version }}
 
-      - name: "Check version bumps per project"
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_REF: ${{ github.base_ref }}
-          SUBDIRS: ${{ inputs.subdirs }}
+      - name: "Check version was bumped"
+        if: steps.classify.outputs.substantive == 'true'
         shell: julia --color=yes {0}
         run: |
           using TOML
 
-          # Substantive-file rules: at the repo root, ignore CI/config
-          # metadata files. Inside a named subdir, every change counts.
-          # Per-subdir classification means each project (root + each
-          # named subdir) gets its own scope and is checked
-          # independently — root bump required only when files outside
-          # the metadata set AND outside any named subdir change; named
-          # subdir bump required only when files inside that subdir
-          # change.
-          const IGNORE_AT_ROOT = (".github/", ".pre-commit-config.yaml", ".gitignore", "LICENSE")
+          base_ref = ENV["GITHUB_BASE_REF"]
+          base_project_text = try
+              read(`git show "origin/$base_ref:Project.toml"`, String)
+          catch err
+              println("Could not read Project.toml on origin/$base_ref ($err); skipping check.")
+              exit(0)
+          end
+          base_project = TOML.parse(base_project_text)
+          current_project = TOML.parse(read("Project.toml", String))
 
-          subdirs = filter(!isempty, string.(split(get(ENV, "SUBDIRS", ""), "\n")))
-          projects = vcat([""], subdirs)
-
-          base_ref = ENV["BASE_REF"]
-          repo = ENV["REPO"]
-          pr_number = ENV["PR_NUMBER"]
-
-          files_text = read(`gh api --paginate "repos/$repo/pulls/$pr_number/files" --jq ".[].filename"`, String)
-          changed_files = filter(!isempty, string.(split(strip(files_text), '\n')))
-          println("Changed files in PR #$pr_number:")
-          for f in changed_files
-              println("  $f")
+          if !haskey(base_project, "version")
+              println("Base branch Project.toml has no version field; skipping check.")
+              exit(0)
+          end
+          if !haskey(current_project, "version")
+              error(
+                  "Project.toml on this branch has no version field, but the base " *
+                  "branch ($base_ref) does. Restore the version field and bump it."
+              )
           end
 
-          function in_scope(file, project, all_subdirs)
-              if isempty(project)
-                  any(startswith(file, p) || file == p for p in IGNORE_AT_ROOT) && return false
-                  any(startswith(file, sd * "/") for sd in all_subdirs) && return false
-                  return true
-              else
-                  return startswith(file, project * "/")
-              end
+          base_version = VersionNumber(base_project["version"])
+          current_version = VersionNumber(current_project["version"])
+
+          if current_version > base_version
+              println(
+                  "OK: Project.toml version bumped from $base_version " *
+                  "(origin/$base_ref) to $current_version (PR head)."
+              )
+          else
+              error(
+                  "Project.toml version was not bumped. Current version $current_version " *
+                  "is not greater than the version $base_version on the base branch " *
+                  "($base_ref). Bump the version in Project.toml."
+              )
           end
-
-          function project_path(project)
-              isempty(project) ? "Project.toml" : joinpath(project, "Project.toml")
-          end
-
-          function check_project(project, all_subdirs, base_ref, files)
-              path = project_path(project)
-              label = isempty(project) ? "root" : project
-
-              substantive = filter(f -> in_scope(f, project, all_subdirs), files)
-              if isempty(substantive)
-                  println("$label: no substantive changes; skipping version-bump check.")
-                  return true
-              end
-
-              println("$label: substantive files changed:")
-              for f in substantive
-                  println("  $f")
-              end
-
-              base_text = try
-                  read(`git show "origin/$base_ref:$path"`, String)
-              catch err
-                  println("$label: could not read $path on origin/$base_ref ($err); skipping check.")
-                  return true
-              end
-
-              if !isfile(path)
-                  println("$label: $path is missing in PR head; skipping check.")
-                  return true
-              end
-
-              base_proj = TOML.parse(base_text)
-              current_proj = TOML.parse(read(path, String))
-
-              if !haskey(base_proj, "version")
-                  println("$label: base $path has no version field; skipping check.")
-                  return true
-              end
-              if !haskey(current_proj, "version")
-                  println(stderr, "ERROR: $label: $path on PR head has no version field, but base does. Restore the version and bump it.")
-                  return false
-              end
-
-              base_v = VersionNumber(base_proj["version"])
-              current_v = VersionNumber(current_proj["version"])
-
-              if current_v > base_v
-                  println("$label: $path bumped from $base_v to $current_v. OK.")
-                  return true
-              else
-                  println(stderr, "ERROR: $label has substantive changes but $path version was not bumped (current $current_v not > base $base_v).")
-                  return false
-              end
-          end
-
-          # Evaluate every project so all errors surface before failing.
-          results = [check_project(p, subdirs, base_ref, changed_files) for p in projects]
-          all(results) || error("VersionCheck failed; see errors above.")

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@mf/subdir-inputs
         id: classify
         with:
           subdir: ${{ inputs.subdir }}

--- a/README.md
+++ b/README.md
@@ -148,8 +148,12 @@ the full matrix even on draft PRs, set it to `true`:
 |---|---|---|---|
 | `julia-version` | string | `"1"` | Julia version passed to `julia-actions/setup-julia`. |
 | `julia-arch` | string | runner arch | Architecture of Julia to be used. |
-| `project` | string | `"@."` | Value passed to Julia's `--project` flag. |
+| `subdir` | string | `""` | Subdirectory containing the package's Project.toml (for an in-tree subpackage). When set, Julia activates `<subdir>` for buildpkg and runtest, and `<subdir>` is auto-appended to `paths` so the per-package classify-pr step considers files inside it as in-scope. |
+| `project` | string | `"@."` | Deprecated alias for `subdir`. Value passed to Julia's `--project` flag. Set `subdir` instead; will be removed in a future major release. |
 | `group` | string | `""` | Test group selector. Exposed to tests via the `GROUP` environment variable so a `runtests.jl` can selectively run a subset. |
+| `test-args` | string | `""` | Newline-separated arguments forwarded to `Pkg.test(; test_args=...)` (via `julia-actions/julia-runtest`'s `test_args` input). Useful when `runtests.jl` selects test groups via `ARGS` rather than the `GROUP` env-var. |
+| `paths` | string | `""` | Positive scope for the substantive-PR check: a file triggers tests iff it equals one of these paths or starts with `<path>/`. Newline-separated. Mutually exclusive with `exclude-paths`. The `subdir` input (if set) is auto-appended. |
+| `exclude-paths` | string | `.gitignore`<br>`.pre-commit-config.yaml` | Negative scope: a file does NOT trigger tests if it matches one of these paths. Default ignores pure metadata files only — workflow file edits (`.github/workflows/**`) do count, by design. Override entirely (defaults are not implicitly preserved). |
 | `self-hosted` | bool | `false` | Run on a self-hosted runner instead of `os`. |
 | `os` | string | `"ubuntu-latest"` | Runner image used when `self-hosted` is `false`. |
 | `nthreads` | number | `1` | Value of `JULIA_NUM_THREADS`. |
@@ -430,6 +434,7 @@ jobs:
 |---|---|---|---|
 | `julia-version` | string | `"1"` | Julia version passed to `julia-actions/setup-julia`. |
 | `localregistry` | string | `""` | Newline-separated list of extra registry URLs (besides General) to scan for dependency updates. |
+| `subdir` | string | `""` | Subdirectory containing the package's Project.toml (for an in-tree subpackage). When set, CompatHelper bumps `<subdir>/Project.toml` plus its `<subdir>/{docs,examples,test}/Project.toml` siblings if present. Empty (default) bumps the standard root + docs + examples + test set. |
 
 ### Secrets
 
@@ -600,7 +605,10 @@ jobs:
 | `julia-version` | string | `"1"` | Julia version passed to `julia-actions/setup-julia`. |
 | `pkgs` | string | **required** | JSON-array string of registered package names and/or git URLs. Use `'[]'` to configure no downstream tests. |
 | `localregistry` | string | `""` | Newline-separated list of extra registry URLs to add before resolving. |
+| `subdir` | string | `""` | Run the downstream tests against the package located in this subdirectory (rather than the repo root). When set, `<subdir>` is also auto-appended to `paths` so the per-package classify-pr considers files inside it as in-scope. |
 | `extra-dev-paths` | string | `""` | Newline-separated list of additional local package paths to develop alongside the repository root before testing downstream packages. |
+| `paths` | string | `""` | Positive scope for the substantive-PR check: a file triggers IntegrationTest iff it equals one of these paths or starts with `<path>/`. Newline-separated. Mutually exclusive with `exclude-paths`. The `subdir` input (if set) is auto-appended. |
+| `exclude-paths` | string | `.gitignore`<br>`.pre-commit-config.yaml` | Negative scope: a file does NOT trigger IntegrationTest if it matches one of these. Default ignores pure metadata files only. Override entirely. |
 | `run-on-draft` | bool | `false` | Run integration tests on draft PRs. When `false`, draft PRs skip integration tests entirely. |
 
 The companion `IntegrationTestRequest.yml` workflow (used for the `/integrationtest ...` comment trigger shown above) has its own inputs:
@@ -641,9 +649,12 @@ jobs:
 | Input | Type | Default | Description |
 |---|---|---|---|
 | `julia-version` | string | `"1"` | Julia version passed to `julia-actions/setup-julia`. |
-| `localregistry` | string | `""` | Newline-separated list of extra registry URLs to consult when determining the previously registered version. |
+| `localregistry` | string | `""` | Unused, kept for backward compat with existing callers. |
+| `subdir` | string | `""` | Subdirectory containing the package's Project.toml (for an in-tree subpackage). When set, the version-bump check reads `<subdir>/Project.toml` instead of root, and `<subdir>` is auto-appended to `paths` so the substantive-PR check is scoped to that subpackage. |
+| `paths` | string | `""` | Positive scope for the substantive-PR check: a file triggers VersionCheck iff it matches one of these paths. Newline-separated. Mutually exclusive with `exclude-paths`. |
+| `exclude-paths` | string | `.gitignore`<br>`.pre-commit-config.yaml`<br>`.github` | Negative scope: a file does NOT trigger VersionCheck if it matches one of these. Default ignores pure metadata plus `.github` (workflow-only PRs don't require a version bump). Override entirely. |
 
-The check is automatically skipped on PRs classified as non-substantive (changes limited to `.github/**`, `.pre-commit-config.yaml`, `.gitignore`, or `LICENSE`); those PRs pass without requiring a version bump.
+The version-bump check is skipped (reported as success) when classify-pr says no in-scope files changed — for example a workflow-only PR on a single-package consumer (default `exclude-paths` includes `.github`), or an NDTensors-only PR on a multi-package caller scoped to root via `exclude-paths: NDTensors`.
 
 ## Check Compat Bounds
 
@@ -685,7 +696,8 @@ jobs:
 | Input | Type | Default | Description |
 |---|---|---|---|
 | `julia-version` | string | `"1"` | Julia version passed to `julia-actions/setup-julia`. |
-| `project` | string | `"@."` | Value passed to Julia's `--project` flag during `julia-actions/julia-buildpkg`. |
+| `subdir` | string | `""` | Subdirectory containing the package's Project.toml (for an in-tree subpackage). When set, both `project` (buildpkg's `--project`) and `workspace-root` (the check-compat-bounds script's workspace root) resolve to `<subdir>`. |
+| `project` | string | `"@."` | Deprecated alias for `subdir`. Value passed to Julia's `--project` flag during `julia-actions/julia-buildpkg`. When `subdir` is set, it takes precedence. |
 | `cache` | bool | `true` | Use `julia-actions/cache`. |
 | `buildpkg` | bool | `true` | Run `julia-actions/julia-buildpkg` before the check. Disable only if the workspace is instantiated some other way. |
 | `localregistry` | string | `""` | Newline-separated list of extra registry URLs to add before resolving (forwarded to `julia-actions/julia-buildpkg`). |
@@ -851,6 +863,7 @@ jobs:
 | `localregistry` | Local registry repo (`owner/name`) for packages not in General | `""` |
 | `trigger` | Comment trigger phrase for on-demand registration | `/register` |
 | `julia-version` | Julia version used by the workflow | `1` |
+| `subdir` | Subdirectory containing the package's Project.toml (for an in-tree subpackage). When set, the workflow reads `package/<subdir>/Project.toml` instead of root and posts `@JuliaRegistrator register subdir=<subdir>`, so multi-package repos can auto-register each in-tree package via a matrix invocation. | `""` |
 
 ### Secrets
 


### PR DESCRIPTION
## Summary

Adds subdir-aware inputs to the standard ITensorActions reusables so
multi-package repositories (e.g. ITensors.jl with its in-tree NDTensors
subpackage) can use them directly instead of maintaining custom workflow
YAML. Also makes IntegrationTest skip metadata-only PRs by default,
saving CI compute ecosystem-wide.

Backward-compatible — single-package consumers pinned to `v2` see no
behavior change, smoke-tested via [SparseArraysBase.jl#179](https://github.com/ITensor/SparseArraysBase.jl/pull/179).

Shipping as `v2.2.0`.

## Test plan

- [x] [SparseArraysBase.jl#179](https://github.com/ITensor/SparseArraysBase.jl/pull/179) — single-package consumer compatibility verified.
- [ ] [ITensors.jl#1743](https://github.com/ITensor/ITensors.jl/pull/1743) — multi-package case CI green.
- [ ] After merge: tag `v2.2.0` at merge commit, force-update `v2`.