### PR TITLE
IntegrationTest: skip aggregate gate on draft PRs

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -221,6 +221,10 @@ jobs:
   # that branch protection can require. Behavior:
   #   - matrix succeeded            -> pass
   #   - `pkgs: '[]'`                -> pass (no downstream configured)
+  #   - draft + run-on-draft=false  -> skip (matches the matrix-leg's draft
+  #                                    skip; gate appears as Skipped on the PR
+  #                                    rather than Failure for the expected
+  #                                    no-signal case)
   #   - matrix all-skipped + fork   -> fail with /integrationtest hint
   #   - any failure                 -> fail
   # The fork-PR-all-skipped case is the trigger for the manual
@@ -229,7 +233,7 @@ jobs:
   gate:
     name: "IntegrationTest"
     needs: integration-test
-    if: ${{ always() }}
+    if: ${{ always() && (!github.event.pull_request.draft || inputs.run-on-draft) }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/README.md
+++ b/README.md
@@ -567,9 +567,11 @@ success, satisfying the gate.
 
 ### Draft PR behavior
 
-By default, integration tests are skipped entirely for draft PRs. This is
-controlled by the `run-on-draft` input (default: `false`). To run integration
-tests even on draft PRs, set it to `true`:
+By default, integration tests are skipped entirely for draft PRs. The matrix
+legs and the aggregate `IntegrationTest` gate both report as Skipped (not
+Failure) — the no-signal case on a draft is treated as expected, not a fault.
+This is controlled by the `run-on-draft` input (default: `false`). To run
+integration tests even on draft PRs, set it to `true`:
 
 ```yaml
     uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v2"


### PR DESCRIPTION
## Summary

- Make the `IntegrationTest` aggregate gate inherit the matrix-leg's draft predicate so it appears as Skipped (not Failure) on draft PRs with `run-on-draft: false` (the default).
- Update `README.md`'s "Draft PR behavior" section to reflect this.

The matrix-driven `integration-test` job skips when `draft && !run-on-draft`. The gate job ran with `if: always()` and its script's "matrix all-skipped" branch — designed for the *unexpected* all-skipped case — fired with `Integration matrix unexpectedly all skipped`, turning the `IntegrationTest` check Red on every draft PR. Non-draft and `run-on-draft: true` paths are unchanged; the unexpected-all-skipped error path remains for genuine matrix scheduling flukes.