### PR TITLE
Unpin internal references on main

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -82,7 +82,7 @@ jobs:
           project: "${{ inputs.subdir != '' && inputs.subdir || inputs.project }}"
 
       - name: "Check compat upper bounds"
-        uses: ITensor/ITensorActions/.github/actions/check-compat-bounds@fe3dfd399dc770aeb0e151e04dbd3d4627b9e603
+        uses: ITensor/ITensorActions/.github/actions/check-compat-bounds@main
         with:
           workspace-root: "${{ inputs.subdir != '' && inputs.subdir || inputs.workspace-root }}"
           mode: "${{ inputs.mode }}"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -70,7 +70,7 @@ jobs:
         pkg: ${{ fromJSON(inputs.pkgs) }}
 
     steps:
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@fe3dfd399dc770aeb0e151e04dbd3d4627b9e603
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
         id: classify
         with:
           # `subdir` (the in-tree package under test) is auto-appended

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -58,7 +58,7 @@ jobs:
   run-tests:
     name: "Run Tests"
     needs: get-pr-comment
-    uses: ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@fe3dfd399dc770aeb0e151e04dbd3d4627b9e603
+    uses: ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main
     with:
       localregistry: "${{ inputs.localregistry }}"
       extra-dev-paths: "${{ inputs.extra-dev-paths }}"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         subdir: "${{ fromJSON(inputs.subdirs) }}"
     steps:
-      - uses: "ITensor/ITensorActions/.github/actions/tag-subdir@fe3dfd399dc770aeb0e151e04dbd3d4627b9e603"
+      - uses: "ITensor/ITensorActions/.github/actions/tag-subdir@main"
         with:
           subdir: "${{ matrix.subdir }}"
           token: "${{ secrets.TAGBOT_PAT || github.token }}"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -140,7 +140,7 @@ jobs:
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@fe3dfd399dc770aeb0e151e04dbd3d4627b9e603
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
         id: classify
         with:
           # `subdir` (the package being tested) is auto-appended to

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ITensor/ITensorActions/.github/actions/classify-pr@fe3dfd399dc770aeb0e151e04dbd3d4627b9e603
+      - uses: ITensor/ITensorActions/.github/actions/classify-pr@main
         id: classify
         with:
           # `subdir` (the in-tree package whose Project.toml is checked) is


### PR DESCRIPTION
## Summary

- Restore `@main` refs for internal self-references in workflow files; the SHA-pinned values were the artifact of the v2.3.0 release rewrite in `.scripts/release.sh` and were never meant to land on `main`.
- Affects `Tests.yml`, `IntegrationTest.yml`, `IntegrationTestRequest.yml`, `VersionCheck.yml`, `CheckCompatBounds.yml`, and `TagBot.yml`.
- Stops Dependabot from opening internal-bump PRs against these refs (#112, #115).

Closes #112, closes #115.