### PR TITLE
Disable cache-on-failure (`save-always: false` on julia-actions/cache@v3)

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -74,6 +74,9 @@ jobs:
         if: "${{ inputs.cache }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
+          # See the comment in `Tests.yml`: don't cache a failed job's
+          # half-installed depot, which would otherwise poison the cache.
+          save-always: false
 
       - uses: julia-actions/julia-buildpkg@v1
         if: "${{ inputs.buildpkg }}"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -98,6 +98,9 @@ jobs:
         if: "${{ inputs.cache }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
+          # See the comment in `Tests.yml`: don't cache a failed job's
+          # half-installed depot, which would otherwise poison the cache.
+          save-always: false
 
       - name: "Export extra environment variables"
         if: "${{ inputs.extra-env != '' }}"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -64,6 +64,10 @@ jobs:
           arch: "x64"
 
       - uses: julia-actions/cache@v3
+        with:
+          # See the comment in `Tests.yml`: don't cache a failed job's
+          # half-installed depot, which would otherwise poison the cache.
+          save-always: false
 
       - name: "Install ITensorFormatter"
         run: |

--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -54,6 +54,10 @@ jobs:
           arch: "${{ runner.arch }}"
 
       - uses: julia-actions/cache@v3
+        with:
+          # See the comment in `Tests.yml`: don't cache a failed job's
+          # half-installed depot, which would otherwise poison the cache.
+          save-always: false
 
       - name: "Install ITensorFormatter"
         run: |

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -76,6 +76,9 @@ jobs:
       - uses: julia-actions/cache@v3
         with:
           delete-old-caches: false
+          # See the comment in `Tests.yml`: don't cache a failed job's
+          # half-installed depot, which would otherwise poison the cache.
+          save-always: false
 
       - name: "Checkout package"
         uses: actions/checkout@v6

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -180,6 +180,11 @@ jobs:
         if: "${{ steps.classify.outputs.triggers == 'true' && inputs.cache }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
+          # Restore the pre-v3 behavior: don't save a cache from a failed
+          # job. v3 caches on failure by default, which poisons the cache
+          # with broken state (e.g. a half-installed depot) and makes every
+          # subsequent run restore that broken state and fail the same way.
+          save-always: false
 
       - uses: julia-actions/julia-buildpkg@v1
         if: "${{ steps.classify.outputs.triggers == 'true' && inputs.buildpkg }}"


### PR DESCRIPTION
## Summary

`julia-actions/cache@v3` (introduced via #118) saves caches **on job failure** by default, where v2 only saved on success. The escape hatch documented in the v3 release notes is `save-always: false`. This PR sets that on every `julia-actions/cache@v3` invocation in the reusable workflows here.

The new v3 default is reasonable for the common case (test-failure retries reuse the expensive depot install). But when the failure is in the *setup* itself — a half-installed depot, an aborted `Pkg` precompile — the broken state is cached, the restore-key prefix matches subsequent runs, and every retry restores the broken state and fails identically. Reruns alone can't recover; the cache has to be manually evicted or expire.

This was hit on [`ITensor/ITensorNetworks.jl#373`](https://github.com/ITensor/ITensorNetworks.jl/pull/373): a fresh Windows run failed in `Pkg.test` precompilation (`ChainRulesCore is required but does not seem to be installed`), the broken state was cached, and two reruns reproduced the failure verbatim by restoring from that cache.