### PR TITLE
VersionCheck: exclude jenkins/ by default

### DIFF
--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -24,11 +24,12 @@ on:
         required: false
         type: string
       exclude-paths:
-        description: "Newline-separated list of path prefixes / files defining negative scope for the substantive-PR check. A file does NOT trigger VersionCheck if it matches one of these. Default ignores `.gitignore`, `.pre-commit-config.yaml`, and `.github` (workflow / config metadata changes don't require a version bump)."
+        description: "Newline-separated list of path prefixes / files defining negative scope for the substantive-PR check. A file does NOT trigger VersionCheck if it matches one of these. Default ignores `.gitignore`, `.pre-commit-config.yaml`, `.github`, and `jenkins` (workflow / config metadata changes don't require a version bump)."
         default: |
           .gitignore
           .pre-commit-config.yaml
           .github
+          jenkins
         required: false
         type: string
 


### PR DESCRIPTION
## Summary

- Add `jenkins` to the default `exclude-paths` for VersionCheck, alongside the existing `.gitignore` / `.pre-commit-config.yaml` / `.github`. Jenkins CI infrastructure (Jenkinsfile, Dockerfile) is workflow / config metadata, same shape as `.github` — changes there don't require a Julia package version bump.
- Multiple ITensor org repos already have a `jenkins/` directory (e.g. ITensors.jl#1754, Tennis.jl), so making this the ecosystem-wide default avoids per-caller boilerplate.