### PR TITLE
CompatHelper: skip subdirs whose Project.toml doesn't exist

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -28,6 +28,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: "Checkout repository"
+        # CompatHelper.main clones the repo internally, but we also need the
+        # source on the runner so we can filter the `subdirs` list against
+        # which Project.tomls actually exist before passing it in.
+        # CompatHelper otherwise crashes on the first missing subdir and
+        # silently drops every later subdir in the list.
+        uses: actions/checkout@v6
+
       - name: "Check if Julia is already available in the PATH"
         id: julia_in_path
         run: which julia
@@ -115,6 +123,14 @@ jobs:
           subdir = get(ENV, "SUBDIR", "")
           subdirs = ["", "docs", "examples", "test"]
           isempty(subdir) || (subdirs = joinpath.(subdir, subdirs))
+          # Drop subdirs that don't actually have a Project.toml. Without
+          # this, CompatHelper throws `LoadError: ".../Project.toml": No
+          # such file` on the first missing one and silently skips every
+          # later subdir, dropping PRs it should have opened. The
+          # `actions/checkout` step above puts the source on the runner
+          # so we can do this check.
+          workspace = ENV["GITHUB_WORKSPACE"]
+          filter!(d -> isfile(joinpath(workspace, d, "Project.toml")), subdirs)
           token_owner = get(ENV, "TOKEN_OWNER", "")
           # If TOKEN_OWNER contains a JSON error body (happens when only GITHUB_TOKEN
           # is available, e.g. in private repos without COMPATHELPER_PAT), treat it as


### PR DESCRIPTION
## Summary

- Add an `actions/checkout` step before the CompatHelper Julia script and filter the hardcoded `subdirs = ["", "docs", "examples", "test"]` list to those that actually have a `Project.toml` on disk. Without this, a missing subdir's `Project.toml` raises `LoadError: ".../Project.toml": No such file` mid-iteration; the exception terminates the run and every later subdir in the list is silently dropped — PRs that should have been opened never appear.
- Surfaced when ITensors.jl#1756 (root weakdep `VectorInterface` bump) was opened but no corresponding PR appeared for `test/Project.toml`. The root CompatHelper job crashed on the (non-existent) `examples/Project.toml` after opening the root PR, before reaching `test/Project.toml`. The same silent-drop also affects `CompatHelperNDTensors` (missing `NDTensors/docs/Project.toml`).