### PR TITLE
Qualify issue references in registration release notes

### DIFF
--- a/.github/actions/version-helpers/version_helpers.jl
+++ b/.github/actions/version-helpers/version_helpers.jl
@@ -182,6 +182,15 @@ function registrator_metadata(;
         readchomp(`git -C $package_path log -1 --pretty=%s HEAD`),
         ['\n', '\r'] => ' '
     )
+    # The subject becomes release-notes text rendered in a foreign repo (the
+    # local registry PR, or the General PR via JuliaRegistrator), where a bare
+    # `#123` from the package's squash-merge subject would auto-link to that
+    # repo's issue #123 instead of the package's. Qualify it with the source
+    # repo so the reference resolves where it was written.
+    repo = get(ENV, "GITHUB_REPOSITORY", "")
+    if !isempty(repo)
+        subject = replace(subject, r"(?<![\w/])#(\d+)" => SubstitutionString("$repo#\\1"))
+    end
 
     if isempty(old_ref) || old_ref == "0000000000000000000000000000000000000000"
         old_ref = try


### PR DESCRIPTION
## Summary

Registration release notes carry the registered package's squash-merge commit subject, which usually ends in a bare `#123` PR reference. That text is then rendered in a different repo (the local registry PR, or the General PR via JuliaRegistrator), where GitHub resolves `#123` against *that* repo, linking to an unrelated issue instead of the package's own PR. This qualifies any bare `#N` in the subject with the source repo from `GITHUB_REPOSITORY` (so `#123` becomes `owner/repo#123`), which resolves correctly wherever the notes are shown. Already-qualified `owner/repo#N` references and non-issue uses of `#` are left alone.